### PR TITLE
Fixed updating issue

### DIFF
--- a/RiiConnect24Patcher.bat
+++ b/RiiConnect24Patcher.bat
@@ -1234,7 +1234,7 @@ set /a file=%file%+1
 goto update_2
 :update_3
 
-curl -s -S --insecure "%FilesHostedOn%/RiiConnect24Patcher.bat" --output RiiConnect24Patcher.bat
+curl -crlf -s -S --insecure "%FilesHostedOn%/RiiConnect24Patcher.bat" --output RiiConnect24Patcher.bat
 
 echo echo off >>temp.bat
 echo ping localhost -n 2^>NUL >>temp.bat

--- a/RiiConnect24Patcher.bat
+++ b/RiiConnect24Patcher.bat
@@ -1,14 +1,15 @@
 @echo off
 setlocal enableextensions
+setlocal enableDelayedExpansion
 cd /d "%~dp0"
 echo 	Starting up...
 echo	The program is starting...
 :: ===========================================================================
 :: RiiConnect24 Patcher for Windows
-set version=1.1.0
+set version=1.1.2.3
 :: AUTHORS: KcrPL, Larsenv, Apfel
 :: ***************************************************************************
-:: Copyright (c) 2019 KcrPL, RiiConnect24 and it's (Lead) Developers
+:: Copyright (c) 2018-2019 KcrPL, RiiConnect24 and it's (Lead) Developers
 :: ===========================================================================
 
 if exist temp.bat del /q temp.bat
@@ -33,12 +34,17 @@ set /a tempsdcardapps=0
 set /a troubleshoot_auto_tool_notification=0
 set sdcard=NUL
 set tempgotonext=begin_main
+
+set mm=0
+set ss=0
+set cc=0
+set hh=0
+
 :: Window Title
 if %beta%==0 title RiiConnect24 Patcher v%version% Created by @KcrPL, @Larsenv, @Apfel
 if %beta%==1 title RiiConnect24 Patcher v%version% [BETA] Created by @KcrPL, @Larsenv, @Apfel
-set last_build=2019/12/01
-set at=23:06
-if exist "C:\Users\%username%\Desktop\RiiConnect24Patcher.txt" goto debug_load
+set last_build=2019/12/27
+set at=13:47
 :: ### Auto Update ###	
 :: 1=Enable 0=Disable
 :: Update_Activate - If disabled, patcher will not even check for updates, default=1
@@ -47,8 +53,12 @@ if exist "C:\Users\%username%\Desktop\RiiConnect24Patcher.txt" goto debug_load
 :: MainFolder/TempStorage - folder that is used to keep version.txt and whatsnew.txt. These two files are deleted every startup but if offlinestorage will be set 1, they won't be deleted.
 set /a Update_Activate=1
 set /a offlinestorage=0 
-if %beta%==0 set FilesHostedOn=https://raw.githubusercontent.com/KcrPL/KcrPL.github.io/master/Patchers_Auto_Update/RiiConnect24Patcher
-if %beta%==1 set FilesHostedOn=https://raw.githubusercontent.com/KcrPL/KcrPL.github.io/master/Patchers_Auto_Update/RiiConnect24Patcher_Beta
+if %beta%==0 set FilesHostedOn=https://kcrPL.github.io/Patchers_Auto_Update/RiiConnect24Patcher
+if %beta%==1 set FilesHostedOn=https://kcrpl.github.io/Patchers_Auto_Update/RiiConnect24Patcher_Beta
+
+:: Other patchers repositories
+set FilesHostedOn_WiiWarePatcher=https://raw.githubusercontent.com/KcrPL/KcrPL.github.io/master/Patchers_Auto_Update/WiiWare-Patcher
+
 
 
 set FilesHostedOn_Beta=https://raw.githubusercontent.com/KcrPL/KcrPL.github.io/master/Patchers_Auto_Update/RiiConnect24Patcher_Beta
@@ -62,43 +72,52 @@ if %beta%==1 set header=RiiConnect24 Patcher - (C) KcrPL, (C) Larsenv, (C) Apfel
 
 if not exist "%MainFolder%" md "%MainFolder%"
 if not exist "%TempStorage%" md "%TempStorage%"
-:: Checking if I have access to files on your computer
-if exist %TempStorage%\checkforaccess.txt del /q %TempStorage%\checkforaccess.txt
-
-echo test >>"%TempStorage%\checkforaccess.txt"
-set /a file_access=1
-if not exist "%TempStorage%\checkforaccess.txt" set /a file_access=0
-
-if exist "%TempStorage%\checkforaccess.txt" del /q "%TempStorage%\checkforaccess.txt"
-
 
 :: Trying to prevent running from OS that is not Windows.
 if not "%os%"=="Windows_NT" goto not_windows_nt
 
 :: Load background color from file if it exists
-if exist "%TempStorage%\background_color.txt" set /p tempcolor=<"%TempStorage%\background_color.txt"
-if exist "%TempStorage%\background_color.txt" color %tempcolor%
+for /f "usebackq" %%a in ("%TempStorage%\background_color.txt") do color %%a
+
+
+
+
+
 
 :: Check for SD Card
 echo.
 echo .. Checking for SD Card
 echo    Can you see an error box? Press `Continue`.
 echo    There's nothing to worry about, everything is going ok. This error is normal.
-goto detect_sd_card
-goto begin_main
+call :detect_sd_card
+
+call :begin_main
+goto exception_handler
+:exception_handler
+echo.
+echo :----------------------------------------------------:
+echo %header%
+echo An error has occurred during execution of the script.
+echo The script has exited but the exception was handled.
+echo.
+echo You cannot continue.
+echo Press any key to restart the script.
+pause>NUL
+goto script_start
+
 :not_windows_nt
 cls
-echo %header%
 echo.
 echo Hi,
 echo Please don't run RiiConnect24 Patcher in MS-DOS
 echo.
 echo Press any button or CTRL+C to quit.
-pause>NUL
+pause
 exit
 goto not_windows_nt
 :begin_main
 cls
+mode %mode%
 echo %header%
 echo              `..````
 echo              yNNNNNNNNMNNmmmmdddhhhyyyysssooo+++/:--.`
@@ -117,7 +136,7 @@ echo            `mmmmmo hNMMMMMMMMMmddNMMMNNMMMMMMMMMMMMM.  Mail us at support@r
 echo            -mmmmm/ dNMMMMMMMMMNmddMMMNdhdMMMMMMMMMMN
 if not %sdcard%==NUL echo            :mmmmm-`mNMMMMMMMMNNmmmNMMNmmmMMMMMMMMMMd   Detected Wii SD Card: %sdcard%:\
 if %sdcard%==NUL echo            :mmmmm-`mNMMMMMMMMNNmmmNMMNmmmMMMMMMMMMMd   Could not detect your Wii SD Card.
-echo            +mmmmN.-mNMMMMMMMMMNmmmmMMMMMMMMMMMMMMMMy   R. Refresh
+echo            +mmmmN.-mNMMMMMMMMMNmmmmMMMMMMMMMMMMMMMMy   R. Refresh ^| If incorrect, you can change later.
 echo            smmmmm`/mMMMMMMMMMNNmmmmNMMMMNMMNMMMMMNmy.
 echo            hmmmmd`omMMMMMMMMMNNmmmNmMNNMmNNNNMNdhyhh.
 echo            mmmmmh ymMMMMMMMMMNNmmmNmNNNMNNMMMMNyyhhh`
@@ -138,7 +157,7 @@ if %beta%==0 echo                                     :syhdyyyyso+/-`
 
 if %beta%==1 echo ----------------------------------------------------------------------------------------------------:
 if %beta%==1 echo            .sho.          
-if %beta%==1 echo         .oy: :ys.          Warning!
+if %beta%==1 echo         .oy: :ys.          Warning^^!
 if %beta%==1 echo       -sy-     -ss-      
 if %beta%==1 echo    `:ss-   ...   -ss-`   
 if %beta%==1 echo  `:ss-`   .ysy     -ss:`   You are using an experimental version of this program.
@@ -203,6 +222,8 @@ echo.
 echo Fixing - Renaming files error
 echo.
 echo [...] Flushing files
+rmdir /s /q 0001000148415045v512>NUL
+rmdir /s /q 0001000148415050v512>NUL
 rmdir /s /q 0001000148414A45v512>NUL
 rmdir /s /q 0001000148414A50v512>NUL
 rmdir /s /q 0001000148415450v1792>NUL
@@ -279,7 +300,7 @@ echo %random% >>"%temp%\deleteME.txt"
 
 copy "%temp%\deleteME.txt" "%sdcard%:\" >NUL
 set temperrorlev=%errorlevel%
-if %temperrorlev%==0 echo [OK] File saved!
+if %temperrorlev%==0 echo [OK] File saved^^!
 if not %temperrorlev%==0 echo [Error] The file couldn't be saved. Looks like the drive is write protected. Unlock it and try again
 if not %temperrorlev%==0 goto troubleshooting_3_3
 
@@ -287,11 +308,11 @@ if %temperrorlev%==0 del /q %sdcard%:\deleteME.txt
 if %temperrorlev%==0 del /q "%temp%\deleteME.txt"
 set /a temperrorlev=%errorlevel%
 
-if %temperrorlev%==0 echo [OK] File deleted!
+if %temperrorlev%==0 echo [OK] File deleted^^!
 if not %temperrorlev%==0 echo [Error] Deleting file.
 if not %temperrorlev%==0 goto troubleshooting_3_3
 
-echo Everything is ok! Drive is enabled for read/write access.
+echo Everything is ok^^! Drive is enabled for read/write access.
 goto troubleshooting_3_3
 :troubleshooting_3_3
 echo.
@@ -371,12 +392,14 @@ if %Update_Activate%==1 echo 3. Turn off/on updating. [Currently:  ON]
 if %Update_Activate%==0 echo 3. Turn off/on updating. [Currently: OFF]
 if %beta%==0 echo 4. Change updating branch to Beta. [Currently: Stable]
 if %beta%==1 echo 4. Change updating branch to Stable. [Currently: Beta]
+echo 5. Repair patcher file (Redownload)
 echo.
 set /p s=Choose:
 if %s%==1 goto begin_main
 if %s%==2 goto change_color
 if %s%==3 goto change_updating
 if %s%==4 goto change_updating_branch
+if %s%==5 goto update_files
 goto settings_menu
 :change_updating_branch
 cls
@@ -385,8 +408,8 @@ echo ---------------------------------------------------------------------------
 echo.
 echo Please wait... fetching data.
 echo.
-if "%beta%"=="1" goto change_updating_branch_stable
-if "%beta%"=="0" goto change_updating_branch_beta
+if %beta%==1 goto change_updating_branch_stable
+if %beta%==0 goto change_updating_branch_beta
 goto settings_menu
 :change_updating_branch_stable
 set /a stable_available_check=1
@@ -479,7 +502,7 @@ cls
 echo %header%
 echo -----------------------------------------------------------------------------------------------------------------------------
 echo.
-echo WAIT! Are you trying to disable updating? 
+echo WAIT^^! Are you trying to disable updating? 
 echo Please do remember that updates will keep you safe and updated about the patcher.
 echo.
 echo Only use this option for debugging and troubleshooting.
@@ -524,7 +547,7 @@ goto change_color
 :save_color
 if exist "%TempStorage%\background_color.txt" del /q "%TempStorage%\background_color.txt"
 color %tempcolor%
-echo %tempcolor%>>"%TempStorage%\background_color.txt"
+echo>>"%TempStorage%\background_color.txt" %tempcolor%
 goto change_color
 
 
@@ -909,11 +932,11 @@ echo %header%
 echo.
 echo              `..````                                     :-------------------------:
 echo              yNNNNNNNNMNNmmmmdddhhhyyyysssooo+++/:--.`    Downloading curl... Please wait.
-echo              hNNNNNNNNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMd   :-------------------------:
-echo              ddmNNd:dNMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMs   
-echo             `mdmNNy dNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM+   File 1 [3.5MB] out of 1
-echo             .mmmmNs mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:   0%% [          ]
-echo             :mdmmN+`mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM.
+echo              hNNNNNNNNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMd    This can take some time...
+echo              ddmNNd:dNMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMs   :-------------------------:
+echo             `mdmNNy dNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM+   
+echo             .mmmmNs mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:   File 1 [3.5MB] out of 1
+echo             :mdmmN+`mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM.   0%% [          ]
 echo             /mmmmN:-mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMN
 echo             ommmmN.:mMMMMMMMMMMMMmNMMMMMMMMMMMMMMMMMd
 echo             smmmmm`+mMMMMMMMMMNhMNNMNNMMMMMMMMMMMMMMy
@@ -943,43 +966,7 @@ echo                                     :syhdyyyyso+/-`
 call powershell -command (new-object System.Net.WebClient).DownloadFile('"%FilesHostedOn%/curl.exe"', '"curl.exe"')
 set /a temperrorlev=%errorlevel%
 if not %temperrorlev%==0 goto begin_main_download_curl_error
-cls
-echo %header%
-echo.
-echo              `..````                                     :-------------------------:
-echo              yNNNNNNNNMNNmmmmdddhhhyyyysssooo+++/:--.`    Downloading curl... Please wait.
-echo              hNNNNNNNNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMd   :-------------------------:
-echo              ddmNNd:dNMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMs   
-echo             `mdmNNy dNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM+   File 1 [3.5MB] out of 1
-echo             .mmmmNs mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:   100%% [----------]
-echo             :mdmmN+`mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM.
-echo             /mmmmN:-mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMN
-echo             ommmmN.:mMMMMMMMMMMMMmNMMMMMMMMMMMMMMMMMd
-echo             smmmmm`+mMMMMMMMMMNhMNNMNNMMMMMMMMMMMMMMy
-echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+
-echo             mmmmms smMMMMMMMMMmddMMmmNmNMMMMMMMMMMMM:
-echo            `mmmmmo hNMMMMMMMMMmddNMMMNNMMMMMMMMMMMMM.
-echo            -mmmmm/ dNMMMMMMMMMNmddMMMNdhdMMMMMMMMMMN
-echo            :mmmmm-`mNMMMMMMMMNNmmmNMMNmmmMMMMMMMMMMd
-echo            +mmmmN.-mNMMMMMMMMMNmmmmMMMMMMMMMMMMMMMMy
-echo            smmmmm`/mMMMMMMMMMNNmmmmNMMMMNMMNMMMMMNmy.
-echo            hmmmmd`omMMMMMMMMMNNmmmNmMNNMmNNNNMNdhyhh.
-echo            mmmmmh ymMMMMMMMMMNNmmmNmNNNMNNMMMMNyyhhh`
-echo           `mmmmmy hmMMNMNNMMMNNmmmmmdNMMNmmMMMMhyhhy
-echo           -mddmmo`mNMNNNNMMMNNNmdyoo+mMMMNmNMMMNyyys
-echo           :mdmmmo-mNNNNNNNNNNdyo++sssyNMMMMMMMMMhs+-
-echo          .+mmdhhmmmNNNNNNmdysooooosssomMMMNNNMMMm
-echo          o/ossyhdmmNNmdyo+++oooooosssoyNMMNNNMMMM+
-echo          o/::::::://++//+++ooooooo+oo++mNMMmNNMMMm
-echo         `o//::::::::+////+++++++///:/+shNMMNmNNmMM+
-echo         .o////////::+++++++oo++///+syyyymMmNmmmNMMm
-echo         -+//////////o+ooooooosydmdddhhsosNMMmNNNmho            `:/
-echo         .+++++++++++ssss+//oyyysso/:/shmshhs+:.          `-/oydNNNy
-echo           `..-:/+ooss+-`          +mmhdy`           -/shmNNNNNdy+:`
-echo                   `.              yddyo++:    `-/oymNNNNNdy+:`
-echo                                   -odhhhhyddmmmmmNNmhs/:`
-echo                                     :syhdyyyyso+/-`
-timeout 2 /nobreak >NUL
+
 goto begin_main1
 :begin_main_download_curl_error
 cls
@@ -998,12 +985,12 @@ echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+
 echo ---------------------------------------------------------------------------------------------------------------------------
 echo    /---\   ERROR.              
 echo   /     \  There was an error while downloading curl.
-echo  /   !   \ Curl is used for downloading files from update server and files needed for patching. 
+echo  /   ^^!   \ Curl is used for downloading files from update server and files needed for patching. 
 echo  --------- Please restart your PC and try running the patcher again.
 echo            If it won't work, please download curl and put it in a folder next to RiiConnect24 Patcher.bat 
+echo.
 echo       Press any key to open download page in browser and to return to menu.
 echo ---------------------------------------------------------------------------------------------------------------------------
-echo           :mdmmmo-mNNNNNNNNNNdyo++sssyNMMMMMMMMMhs+-                  
 echo          .+mmdhhmmmNNNNNNmdysooooosssomMMMNNNMMMm                     
 echo          o/ossyhdmmNNmdyo+++oooooosssoyNMMNNNMMMM+                    
 echo          o/::::::://++//+++ooooooo+oo++mNMMmNNMMMm                    
@@ -1020,7 +1007,9 @@ start %FilesHostedOn%/curl.exe
 goto begin_main
 
 :begin_main1
-if not exist curl.exe goto begin_main_download_curl
+:: For whatever reason, it returns 2
+curl
+if not %errorlevel%==2 goto begin_main_download_curl
 
 cls
 echo %header%
@@ -1071,9 +1060,10 @@ if not exist "%TempStorage%" md "%TempStorage%"
 if %Update_Activate%==1 if %offlinestorage%==0 call curl -s -S --insecure "%FilesHostedOn%/whatsnew.txt" --output "%TempStorage%\whatsnew.txt"
 if %Update_Activate%==1 if %offlinestorage%==0 call curl -s -S --insecure "%FilesHostedOn%/version.txt" --output "%TempStorage%\version.txt"
 	set /a temperrorlev=%errorlevel%
-
+	
 set /a updateserver=1
 	::Bind exit codes to errors here
+	if "%temperrorlev%"=="6" goto no_internet_connection
 	if not %temperrorlev%==0 set /a updateserver=0
 
 if exist "%TempStorage%\version.txt`" ren "%TempStorage%\version.txt`" "version.txt"
@@ -1092,47 +1082,6 @@ if %Update_Activate%==1 if %updateavailable%==1 set /a updateserver=2
 if %Update_Activate%==1 if %updateavailable%==1 goto update_notice
 
 goto 1
-:powershell_error
-
-:: // Deprecated \\
-
-cls
-echo %header%
-echo.                                                                       
-echo              `..````                                                  
-echo              yNNNNNNNNMNNmmmmdddhhhyyyysssooo+++/:--.`                
-echo              hNNNNNNNNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMd                
-echo              ddmNNd:dNMMMMNMMMMMMMMMMMMMMMMMMMMMMMMMMs                
-echo             `mdmNNy dNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM+        
-echo             .mmmmNs mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM:                
-echo             :mdmmN+`mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM.                
-echo             /mmmmN:-mNMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMN            
-echo             ommmmN.:mMMMMMMMMMMMMmNMMMMMMMMMMMMMMMMMd                 
-echo             smmmmm`+mMMMMMMMMMNhMNNMNNMMMMMMMMMMMMMMy                 
-echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+                 
-echo ------------------------------------------------------------------------------------------------------------------------------
-echo    /---\   An error has occurred. We couldn't run Powershell on your PC.
-echo   /     \  Please disable your antivirus, run RiiConnect24Patcher.bat as an administrator and try again.
-echo  /   !   \ Restarting your PC could also fix the problem.
-echo  ---------
-echo             If you are on an old system like Windows XP, please use our legacy IOS Patcher.
-echo             You can find IOS Patcher at https://github.com/RiiConnect24/IOS-Patcher/releases
-echo ------------------------------------------------------------------------------------------------------------------------------    
-echo           -mddmmo`mNMNNNNMMMNNNmdyoo+mMMMNmNMMMNyyys                  
-echo           :mdmmmo-mNNNNNNNNNNdyo++sssyNMMMMMMMMMhs+-                  
-echo          .+mmdhhmmmNNNNNNmdysooooosssomMMMNNNMMMm                     
-echo          o/ossyhdmmNNmdyo+++oooooosssoyNMMNNNMMMM+                    
-echo          o/::::::://++//+++ooooooo+oo++mNMMmNNMMMm                    
-echo         `o//::::::::+////+++++++///:/+shNMMNmNNmMM+                   
-echo         .o////////::+++++++oo++///+syyyymMmNmmmNMMm                   
-echo         -+//////////o+ooooooosydmdddhhsosNMMmNNNmho            `:/    
-echo         .+++++++++++ssss+//oyyysso/:/shmshhs+:.          `-/oydNNNy   
-echo           `..-:/+ooss+-`          +mmhdy`           -/shmNNNNNdy+:`   
-echo                   `.              yddyo++:    `-/oymNNNNNdy+:`        
-echo                                   -odhhhhyddmmmmmNNmhs/:`             
-echo                                     :syhdyyyyso+/-`
-pause>NUL
-goto begin_main
 :update_notice
 if exist "%MainFolder%\failsafe.txt" del /q "%MainFolder%\failsafe.txt"
 if %updateversion%==0.0.0 goto error_update_not_available
@@ -1154,7 +1103,7 @@ echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+
 echo ------------------------------------------------------------------------------------------------------------------------------
 echo    /---\   An Update is available.              
 echo   /     \  An Update for this program is available. We suggest updating the RiiConnect24 Patcher to the latest version.
-echo  /   !   \ 
+echo  /   ^^!   \ 
 echo  ---------  Current version: %version%
 echo             New version: %updateversion%
 echo                       1. Update                      2. Dismiss               3. What's new in this update?
@@ -1195,9 +1144,9 @@ echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+
 echo ------------------------------------------------------------------------------------------------------------------------------
 echo    /---\   Updating.
 echo   /     \  Please wait...
-echo  /   !   \ 
+echo  /   ^^!   \ 
 echo  --------- RiiConnect24 Patcher will restart shortly... 
-echo.           Now working on: Downloading files from server and replacing old with the new ones. Give me a second, please! :)  
+echo.           Now working on: Downloading files from server and replacing old with the new ones. Give me a second, please^^! :)  
 echo.
 echo ------------------------------------------------------------------------------------------------------------------------------
 echo           -mddmmo`mNMNNNNMMMNNNmdyoo+mMMMNmNMMMNyyys                  
@@ -1234,12 +1183,12 @@ set /a file=%file%+1
 goto update_2
 :update_3
 
-curl -crlf -s -S --insecure "%FilesHostedOn%/RiiConnect24Patcher.bat" --output RiiConnect24Patcher.bat
+curl -crlf -s -S --insecure "%FilesHostedOn%/RiiConnect24Patcher.bat" --output TempRiiConnect24Patcher.bat
 
 echo echo off >>temp.bat
 echo ping localhost -n 2^>NUL >>temp.bat
 echo del RiiConnect24Patcher.bat /q >>temp.bat
-echo ren "RiiConnect24Patcher.bat`" "RiiConnect24Patcher.bat" >>temp.bat
+echo ren "TempRiiConnect24Patcher.bat" "RiiConnect24Patcher.bat" >>temp.bat
 echo start RiiConnect24Patcher.bat >>temp.bat
 echo exit >>temp.bat
 
@@ -1284,10 +1233,254 @@ echo.
 echo 2. Uninstall RiiConnect24 from your Wii.
 echo   - This will help you uninstall RiiConnect24 from your Wii.
 echo.
+echo --- Other patchers ---
+echo.
+echo 3. Patch Wii WAD Games to work with Wiimmfi.
+echo   - This will patch WAD Games (WiiWare) for use with Wiimmfi which will allow you to play online with other people.
+echo.
+echo 4. Patch Mario Kart Wii to work with Wiimmfi.
+echo   - This will patch your copy of Mario Kart Wii to work with Wiimmfi which will enable online multiplayer to work again.
+echo.
+echo 5. Patch other Wii Games to work with Wiimmfi.
+echo   - This will patch any other game than Mario Kart Wii to work with Wiimmfi. 
+echo.	
 set /p s=Choose: 
 if %s%==1 goto 2_auto_ask
 if %s%==2 goto 2_uninstall
+if %s%==3 goto wadgames_patch_info
+if %s%==4 goto mariokartwii_patch
+if %s%==5 goto wiigames_patch
 goto 1
+
+:wiigames_patch
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo Preparing for use with Wiimmfi Patcher...
+echo Please wait...
+echo.
+echo Progress:
+
+set tempCD=%cd%
+
+if exist Wiimmfi-Patcher rmdir /s /q Wiimmfi-Patcher
+md Wiimmfi-Patcher
+echo 25%%
+curl -s -S --insecure "https://download.wiimm.de/wiimmfi/patcher/wiimmfi-patcher-v4.7z" --output "Wiimmfi-Patcher\wiimmfi-patcher-v4.7z"
+echo 50%%
+curl -s -S --insecure "%FilesHostedOn%/7z.exe" --output "Wiimmfi-Patcher\7z.exe"
+echo 75%%
+cd Wiimmfi-Patcher
+7z.exe x wiimmfi-patcher-v4.7z>NUL
+
+cd ..
+
+echo 100%%
+goto wiigames_patch_ask
+
+:wiigames_patch_ask
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo Wiimmfi Patcher is ready^^!
+echo Please the game image (can be ISO or WBFS) in a folder where RiiConnect24 Patcher is and choose "Ready".
+echo.
+if exist "*.ISO" echo ISO Files: Found
+if not exist "*.ISO" echo ISO Files: Not Found
+if exist "*.WBFS" echo WBFS Files: Found
+if not exist "*.WBFS" echo WBFS Files: Not Found
+echo.
+echo 1. Ready. Start Wiimmfi Patcher.
+echo 2. Go back to Main Menu.
+set /p s=Choose: 
+if %s%==1 goto start_wiimmfi-patcher
+if %s%==2 rmdir /s /q Wiimmfi-Patcher&goto begin_main
+goto wiigames_patch_ask
+:start_wiimmfi-patcher
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+
+if exist "*.WBFS" move "*.WBFS" "Wiimmfi-Patcher\wiimmfi-patcher-v4\Windows"
+if exist "*.ISO" move "*.ISO" "Wiimmfi-Patcher\wiimmfi-patcher-v4\Windows"
+
+cd "Wiimmfi-Patcher\wiimmfi-patcher-v4\Windows"
+
+@echo off
+
+wit cp . --DEST ../wiimmfi-images/ --update --psel=data --wiimmfi -vv
+
+cd ..
+cd ..
+cd ..
+
+if not exist wiimmfi-images md wiimmfi-images
+move "Wiimmfi-Patcher\wiimmfi-patcher-v4\wiimmfi-images\*.iso" "wiimmfi-images"
+move "Wiimmfi-Patcher\wiimmfi-patcher-v4\wiimmfi-images\*.wbfs" "wiimmfi-images"
+ping localhost -n 2>NUL
+rmdir Wiimmfi-Patcher
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo The Wiimmfi Patcher is done^^! 
+echo The game image file has been moved to the wiimmfi-images folder next to RiiConnect24 Patcher.
+echo.
+echo Press any button to go back to main menu.
+pause>NUL
+
+goto script_start
+
+:mariokartwii_patch
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo Preparing for use with Mario Kart Wii Wiimmfi Patcher...
+echo Please wait...
+echo.
+echo Progress:
+set tempCD=%cd%
+if exist MKWii-Patcher rmdir /s /q MKWii-Patcher
+md MKWii-Patcher
+echo 25%%
+curl -s -S --insecure "https://download.wiimm.de/wiimmfi/patcher/mkw-wiimmfi-patcher-v6.zip" --output "MKWii-Patcher\mkw-wiimmfi-patcher-v6.zip"
+echo 50%%
+curl -s -S --insecure "%FilesHostedOn%/7z.exe" --output "MKWii-Patcher\7z.exe"
+echo 75%%
+cd MKWii-Patcher
+7z.exe x mkw-wiimmfi-patcher-v6.zip>NUL
+cd..
+echo 100%%
+goto mariokartwii_patch_ask
+
+:mariokartwii_patch_ask
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo Mario Kart Wii Wiimmfi Patcher is ready^^!
+echo Please put the Mario Kart Wii image file (can be ISO or WBFS) in a folder where RiiConnect24 Patcher is and choose "Ready".
+echo.
+if exist "*.ISO" echo ISO Files: Found
+if not exist "*.ISO" echo ISO Files: Not Found
+if exist "*.WBFS" echo WBFS Files: Found
+if not exist "*.WBFS" echo WBFS Files: Not Found
+echo.
+echo 1. Ready. Start Mario Kart Wii Patcher.
+echo 2. Go back to Main Menu.
+set /p s=Choose: 
+if %s%==1 goto start_mkwii-patcher
+if %s%==2 rmdir /s /q MKWii-Patcher&goto begin_main
+goto mariokartwii_patch_ask
+:start_mkwii-patcher
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+set tempCD=%cd%
+if exist "*.WBFS" move "*.WBFS" "MKWii-Patcher\mkw-wiimmfi-patcher-v6\"
+if exist "*.ISO" move "*.ISO" "MKWii-Patcher\mkw-wiimmfi-patcher-v6\"
+
+cd MKWii-Patcher\mkw-wiimmfi-patcher-v6
+
+@echo off
+
+::Actual patching
+set PATH=bin\cygwin;%PATH%
+bash ./patch-wiimmfi.sh %1 %2 %3 %4 %5 %6 %7 %8 %9
+
+cd ..
+cd ..
+
+if not exist wiimmfi-images md wiimmfi-images
+move "MKWii-Patcher\mkw-wiimmfi-patcher-v6\wiimmfi-images\*.iso" "wiimmfi-images"
+move "MKWii-Patcher\mkw-wiimmfi-patcher-v6\wiimmfi-images\*.wbfs" "wiimmfi-images"
+rmdir MKWii-Patcher
+
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo The Wiimmfi Patcher is done^^! 
+echo Mario Kart Wii image file has been moved to the wiimmfi-images folder next to RiiConnect24 Patcher.
+echo.
+echo %tempCD%
+echo Press any button to go back to main menu.
+pause>NUL
+
+goto script_start
+
+
+
+:wadgames_patch_info
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo Preparing for use with WiiWare Patcher...
+echo Please wait...
+echo.
+echo Progress:
+if exist WiiWare-Patcher rmdir /s /q WiiWare-Patcher
+md WiiWare-Patcher
+echo 14%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/libWiiSharp.dll" --output WiiWare-Patcher/libWiiSharp.dll
+echo 28%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/lzx.exe" --output WiiWare-Patcher/lzx.exe
+echo 42%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/patcher.bat" --output WiiWare-Patcher/patcher.bat
+echo 57%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/Sharpii.exe" --output WiiWare-Patcher/Sharpii.exe
+echo 71%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/WadInstaller.dll" --output WiiWare-Patcher/WadInstaller.dll
+echo 85%%
+curl -s -S --insecure "%FilesHostedOn_WiiWarePatcher%/WiiwarePatcher.exe" --output WiiWare-Patcher/WiiwarePatcher.exe
+echo 100%%
+goto wadgames_patch_ask
+:wadgames_patch_ask
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo A WiiWare-Patcher folder has been made. Please put your .WAD files in that folder and choose "Ready" when you're ready.
+echo.
+echo 1. Ready. Start WiiWare Patcher.
+echo 2. Go back to Main Menu.
+set /p s=Choose: 
+if %s%==1 goto start_wiiware-patcher
+if %s%==2 rmdir /s /q WiiWare-Patcher&goto begin_main
+
+:start_wiiware-patcher
+if exist WiiWare-Patcher\RC24PATCHER_START_PATCHING_SCRIPT del /q WiiWare-Patcher\RC24PATCHER_START_PATCHING_SCRIPT
+echo 1>>WiiWare-Patcher\RC24PATCHER_START_PATCHING_SCRIPT
+::
+cd WiiWare-Patcher
+call patcher
+cd..
+::
+cls
+echo Moving files... please wait.
+if exist WiiWare-Patcher\backup-wads md backup-wads
+if exist WiiWare-Patcher\wiimmfi-wads md wiimmfi-wads
+if exist WiiWare-Patcher\backup-wads move "WiiWare-Patcher\backup-wads\*.wad" "backup-wads\"
+if exist WiiWare-Patcher\wiimmfi-wads move "WiiWare-Patcher\wiimmfi-wads\*.wad" "wiimmfi-wads\"
+
+cls
+echo %header%
+echo -----------------------------------------------------------------------------------------------------------------------------
+echo.
+echo WiiWare Patcher has exited...
+echo If the files were patched, you can find the patched .WAD files in the wiimmfi-wads folder next to the RiiConnect24 Patcher.
+echo.
+echo Press any button to return to main menu.
+pause>NUL
+goto script_start
+
+
 :2_uninstall
 cls
 echo %header%
@@ -1369,7 +1562,7 @@ echo After downloading all the files, do you want to copy them to your SD Card?
 echo.
 echo Please connect your Wii SD Card to the computer.
 echo.
-echo 1. Connected!
+echo 1. Connected^^!
 echo 2. I can't connect an SD Card to the computer.
 set sdcard=NUL
 set /p sdcard=Choose: 
@@ -1386,8 +1579,8 @@ if %sdcardstatus%==1 if %sdcard%==NUL echo Hmm... looks like an SD Card wasn't f
 if %sdcardstatus%==1 if %sdcard%==NUL echo to set your SD Card drive letter manually.
 if %sdcardstatus%==1 if %sdcard%==NUL echo.
 if %sdcardstatus%==1 if %sdcard%==NUL echo Otherwise, starting patching will set copying to manual so you will have to copy them later.
-if %sdcardstatus%==1 if not %sdcard%==NUL echo Congrats! I've successfully detected your SD Card! Drive letter: %sdcard%
-if %sdcardstatus%==1 if not %sdcard%==NUL echo I will be able to automatically download and install everything on your SD Card!	
+if %sdcardstatus%==1 if not %sdcard%==NUL echo Congrats^^! I've successfully detected your SD Card^^! Drive letter: %sdcard%
+if %sdcardstatus%==1 if not %sdcard%==NUL echo I will be able to automatically download and install everything on your SD Card^^!	
 echo.
 echo The entire patching process will download about 5MB of data.
 echo.
@@ -1564,7 +1757,7 @@ cls
 echo %header%
 echo -----------------------------------------------------------------------------------------------------------------------------
 echo.
-echo Patching done! Now please follow these instructions:
+echo Patching done^^! Now please follow these instructions:
 echo.
 if %sdcard%==NUL echo - Plaese copy the wad and apps folder next to the patcher to your SD Card.
 if %sdcard%==NUL echo.
@@ -1589,7 +1782,7 @@ echo Part II - Restoring the nwc24msg.cfg to it's factory default.
 echo.
 echo 1. Please launch WiiXplorer from the Homebrew Channel.
 echo 2. In WiiXplorer, press Start -^> Settings -^> Boot Settings -^> NAND Write Access (turn on)
-echo    - Remember to turn it on because it's important!
+echo    - Remember to turn it on because it's important^^!
 echo 3. Change your device to NAND (on the bar on top)
 echo 4. Go to shared2 -^> wc24
 echo 5. Hover your cursor over nwc24msg.cfg, press + on your Wii Remote and delete it.
@@ -1631,7 +1824,7 @@ cls
 echo %header%
 echo -----------------------------------------------------------------------------------------------------------------------------
 echo.
-echo That's it! RiiConnect24 should be now gone from your Wii!
+echo That's it^^! RiiConnect24 should be now gone from your Wii^^!
 echo Please come back to us soon :)
 echo.
 echo Press any key to exit the patcher.
@@ -1654,7 +1847,7 @@ cls
 echo %header%
 echo -----------------------------------------------------------------------------------------------------------------------------
 echo.
-echo Install RiiConnect24
+echo Install RiiConnect24.
 echo.
 echo Choose instalation type:
 echo 1. Express (Recommended)
@@ -1671,6 +1864,7 @@ echo   - You will be asked what you want to patch.
 set /p s=
 if %s%==1 goto 2_auto
 if %s%==2 goto 2_auto_ask_2
+goto 2_auto_ask
 :2_auto_ask_2
 set /a tick=1
 set /a anim_1=1
@@ -1748,7 +1942,7 @@ if %custominstall_nc%==0 echo 4. [ ] Nintendo Channel
 if %custominstall_cmoc%==1 echo 5. [X] Check Mii Out Channel / Mii Contest Channel
 if %custominstall_cmoc%==0 echo 5. [ ] Check Mii Out Channel / Mii Contest Channel
 echo.
-echo 6. Begin patching!
+echo 6. Begin patching^^!
 echo R. Go back.
 set /p s=
 if %s%==1 goto 2_switch_region
@@ -1829,15 +2023,15 @@ cls
 echo %header%
 echo -----------------------------------------------------------------------------------------------------------------------------
 echo.
-echo Great!
-echo After passing this screen, any user interraction won't be needed so you can relax and let me do the work! :)
+echo Great^^!
+echo After passing this screen, any user interraction won't be needed so you can relax and let me do the work^^! :)
 echo.
-echo Did I forget about something? Yes! To make patching even easier, I can download everything that you need and put it on 
-echo your SD Card!
+echo Did I forget about something? Yes^^! To make patching even easier, I can download everything that you need and put it on 
+echo your SD Card^^!
 echo.
 echo Please connect your Wii SD Card to the computer.
 echo.
-echo 1. Connected!
+echo 1. Connected^^!
 echo 2. I can't connect an SD Card to the computer.
 set /p s=
 set sdcard=NUL
@@ -1846,137 +2040,26 @@ if %s%==2 set /a sdcardstatus=0& set /a sdcard=NUL& goto 2_1_summary
 goto 2_1
 :detect_sd_card
 set sdcard=NUL
-set /a check=0
-:sd_a
-set /a check=0
-if exist A:\apps set /a check=%check%+1
-if %check%==1 set sdcard=A
-goto sd_b
-:sd_b
-set /a check=0
-if exist B:\apps set /a check=%check%+1
-if %check%==1 set sdcard=B
-goto sd_d
-:sd_d
-set /a check=0
-if exist D:\apps set /a check=%check%+1
-if %check%==1 set sdcard=D
-goto sd_e
-:sd_e
-set /a check=0
-if exist E:\apps set /a check=%check%+1
-if %check%==1 set sdcard=E
-goto sd_f
-:sd_f
-set /a check=0
-if exist F:\apps set /a check=%check%+1
-if %check%==1 set sdcard=F
-goto sd_g
-:sd_g
-set /a check=0
-if exist G:\apps set /a check=%check%+1
-if %check%==1 set sdcard=G
-goto sd_h
-:sd_h
-set /a check=0
-if exist H:\apps set /a check=%check%+1
-if %check%==1 set sdcard=H
-goto sd_i
-:sd_i
-set /a check=0
-if exist I:\apps set /a check=%check%+1
-if %check%==1 set sdcard=I
-goto sd_j
-:sd_j
-set /a check=0
-if exist J:\apps set /a check=%check%+1
-if %check%==1 set sdcard=J
-goto sd_k
-:sd_k
-set /a check=0
-if exist K:\apps set /a check=%check%+1
-if %check%==1 set sdcard=K
-goto sd_l
-:sd_l
-set /a check=0
-if exist L:\apps set /a check=%check%+1
-if %check%==1 set sdcard=L
-goto sd_m
-:sd_m
-set /a check=0
-if exist M:\apps set /a check=%check%+1
-if %check%==1 set sdcard=M
-goto sd_n
-:sd_n
-set /a check=0
-if exist N:\apps set /a check=%check%+1
-if %check%==1 set sdcard=N
-goto sd_o
-:sd_o
-set /a check=0
-if exist O:\apps set /a check=%check%+1
-if %check%==1 set sdcard=O
-goto sd_p
-:sd_p
-set /a check=0
-if exist P:\apps set /a check=%check%+1
-if %check%==1 set sdcard=P
-goto sd_q
-:sd_q
-set /a check=0
-if exist Q:\apps set /a check=%check%+1
-if %check%==1 set sdcard=Q
-goto sd_r
-:sd_r
-set /a check=0
-if exist R:\apps set /a check=%check%+1
-if %check%==1 set sdcard=R
-goto sd_s
-:sd_s
-set /a check=0
-if exist S:\apps set /a check=%check%+1
-if %check%==1 set sdcard=S
-goto sd_t
-:sd_t
-set /a check=0
-if exist T:\apps set /a check=%check%+1
-if %check%==1 set sdcard=T
-goto sd_u
-:sd_u
-set /a check=0
-if exist U:\apps set /a check=%check%+1
-if %check%==1 set sdcard=U
-goto sd_v
-:sd_v
-set /a check=0
-if exist V:\apps set /a check=%check%+1
-if %check%==1 set sdcard=V
-goto sd_w
-:sd_w
-set /a check=0
-if exist W:\apps set /a check=%check%+1
-if %check%==1 set sdcard=W
-goto sd_x
-:sd_x
-set /a check=0
-if exist X:\apps set /a check=%check%+1
-if %check%==1 set sdcard=X
-goto sd_y
-:sd_y
-set /a check=0
-if exist Y:\apps set /a check=%check%+1
-if %check%==1 set sdcard=Y
-goto sd_z
-:sd_z
-set /a check=0
-if exist Z:\apps set /a check=%check%+1
-if %check%==1 set sdcard=Z
+set counter=-1
+set letters=ABDEFGHIJKLMNOPQRSTUVWXYZ
+set looking_for=
+:detect_sd_card_2
+set /a counter=%counter%+1
+set looking_for=!letters:~%counter%,1!
+if exist %looking_for%:/apps (
+set sdcard=%looking_for%
 call :%tempgotonext%
-echo.
-echo ---------------------------------------------
-echo There was an error while returning to script. Halting now. You will be returned to main menu.
-pause
-goto begin_main
+exit
+exit
+)
+
+if %looking_for%==Z (
+set sdcard=NUL
+call :%tempgotonext%
+exit
+exit
+)
+goto detect_sd_card_2
 
 :2_1_summary
 cls
@@ -1988,8 +2071,8 @@ if %sdcardstatus%==1 if %sdcard%==NUL echo Hmm... looks like an SD Card wasn't f
 if %sdcardstatus%==1 if %sdcard%==NUL echo to set your SD Card drive letter manually.
 if %sdcardstatus%==1 if %sdcard%==NUL echo.
 if %sdcardstatus%==1 if %sdcard%==NUL echo Otherwise, starting patching will set copying to manual so you will have to copy them later.
-if %sdcardstatus%==1 if not %sdcard%==NUL echo Congrats! I've successfully detected your SD Card! Drive letter: %sdcard%
-if %sdcardstatus%==1 if not %sdcard%==NUL echo I will be able to automatically download and install everything on your SD Card!	
+if %sdcardstatus%==1 if not %sdcard%==NUL echo Congrats^^! I've successfully detected your SD Card^^! Drive letter: %sdcard%
+if %sdcardstatus%==1 if not %sdcard%==NUL echo I will be able to automatically download and install everything on your SD Card^^!	
 echo.
 echo The entire patching process will download about 30MB of data.
 echo.
@@ -2030,9 +2113,13 @@ set /a progress_nc=0
 set /a progress_cmoc=0
 set /a progress_finishing=0
 
-goto 2_3
+goto random_funfact
 :random_funfact
 
+:: Get start time:
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do (
+   set /A "start=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100"
+)
 set /a funfact_number=%random% %% (1 + 30)
 if /i %funfact_number% LSS 1 goto random_funfact
 if /i %funfact_number% GTR 30 goto random_funfact
@@ -2045,7 +2132,7 @@ if %funfact_number%==6 set funfact=Did you know the letters in the Wii model num
 if %funfact_number%==7 set funfact=The music used in many of the Wii's channels (including the Wii Shop, Mii, Check Mii Out, and Forecast Channel) was composed by Kazumi Totaka.
 if %funfact_number%==8 set funfact=The Internet Channel once costed 500 Wii Points.
 if %funfact_number%==9 set funfact=It's possible to use candles as a Wii Sensor Bar.
-if %funfact_number%==10 set funfact=The blinking blue light that indicates a system message has been received is actually synced to the bird call of the Japanese bush warbler. More info about it on RiiConnect24 YouTube Channel!
+if %funfact_number%==10 set funfact=The blinking blue light that indicates a system message has been received is actually synced to the bird call of the Japanese bush warbler. More info about it on RiiConnect24 YouTube Channel^^!
 if %funfact_number%==11 set funfact=Wii sports is the most sold game on the Wii. It sold 82.85 million. Overall it is the 3rd most sold game in the world.
 if %funfact_number%==12 set funfact=Did you know that most of the scripts used to make RiiConnect24 work are written in Python?
 if %funfact_number%==13 set funfact=Thank you Spotlight for making our mail system secure.
@@ -2067,9 +2154,28 @@ if %funfact_number%==28 set funfact=The night song that plays when viewing the l
 if %funfact_number%==29 set funfact=The globe in the Forecast and News Channel is based on imagery from NASA, and the same globe was used in Mario Kart Wii.
 if %funfact_number%==30 set funfact=You can press the Reset button while the Wii's in standby to turn off the blue light that glows when you receive a message.
 
+
+
+
 set /a percent=%percent%+1
 goto 2_3
 :2_3
+:: Get end time:
+for /F "tokens=1-4 delims=:.," %%a in ("%time%") do (
+   set /A "end=(((%%a*60)+1%%b %% 100)*60+1%%c %% 100)*100+1%%d %% 100"
+)
+
+rem Get elapsed time:
+set /A elapsed=end-start
+
+
+rem Show elapsed time:
+set /A hh=elapsed/(60*60*100), rest=elapsed%%(60*60*100), mm=rest/(60*100), rest%%=60*100, ss=rest/100, cc=rest%%100
+if %mm% lss 10 set mm=%mm%
+if %ss% lss 10 set ss=%ss%
+if %cc% lss 10 set cc=%cc%
+
+
 if /i %percent% GTR 0 if /i %percent% LSS 10 set /a counter_done=0
 if /i %percent% GTR 10 if /i %percent% LSS 20 set /a counter_done=1
 if /i %percent% GTR 20 if /i %percent% LSS 30 set /a counter_done=2
@@ -2092,7 +2198,13 @@ if %troubleshoot_auto_tool_notification%==1 echo : Warning: There was an error w
 if %troubleshoot_auto_tool_notification%==1 echo : the problem. The patching process has been restarted.                                                                  :
 if %troubleshoot_auto_tool_notification%==1 echo :------------------------------------------------------------------------------------------------------------------------:
 echo.
+
+set /a refreshing_in=20-"%ss%">>NUL
+echo ---------------------------------------------------------------------------------------------------------------------------
 echo Fun Fact: %funfact%
+echo ---------------------------------------------------------------------------------------------------------------------------
+if /i %refreshing_in% GTR 0 echo Next fun fact... %refreshing_in% sec
+if /i %refreshing_in% LEQ 0 echo Next fun fact... 0 sec
 echo.
 echo    Progress:
 if %counter_done%==0 echo :          : %percent% %%
@@ -2109,22 +2221,24 @@ if %counter_done%==10 echo :----------: %percent% %%
 echo.
 if %progress_downloading%==0 echo [ ] Downloading files
 if %progress_downloading%==1 echo [X] Downloading files
-if %progress_ios%==0 echo [ ] Patching IOS's
-if %progress_ios%==1 echo [X] Patching IOS's
-if %progress_evc%==0 echo [ ] Everybody Votes Channel
-if %progress_evc%==1 echo [X] Everybody Votes Channel
-if %evcregion%==1 if %progress_cmoc%==0 echo [ ] Mii Contest Channel
-if %evcregion%==1 if %progress_cmoc%==1 echo [X] Mii Contest Channel
-if %evcregion%==2 if %progress_cmoc%==0 echo [ ] Check Mii Out Channel
-if %evcregion%==2 if %progress_cmoc%==1 echo [X] Check Mii Out Channel
-if %progress_nc%==0 echo [ ] Nintendo Channel
-if %progress_nc%==1 echo [X] Nintendo Channel
+if %custominstall_ios%==1 if %progress_ios%==0 echo [ ] Patching IOS's
+if %custominstall_ios%==1 if %progress_ios%==1 echo [X] Patching IOS's
+if %custominstall_evc%==1 if %progress_evc%==0 echo [ ] Everybody Votes Channel
+if %custominstall_evc%==1 if %progress_evc%==1 echo [X] Everybody Votes Channel
+if %custominstall_cmoc%==1 if %evcregion%==1 if %progress_cmoc%==0 echo [ ] Mii Contest Channel
+if %custominstall_cmoc%==1 if %evcregion%==1 if %progress_cmoc%==1 echo [X] Mii Contest Channel
+if %custominstall_cmoc%==1 if %evcregion%==2 if %progress_cmoc%==0 echo [ ] Check Mii Out Channel
+if %custominstall_cmoc%==1 if %evcregion%==2 if %progress_cmoc%==1 echo [X] Check Mii Out Channel
+if %custominstall_nc%==1 if %progress_nc%==0 echo [ ] Nintendo Channel
+if %custominstall_nc%==1 if %progress_nc%==1 echo [X] Nintendo Channel
 if %progress_finishing%==0 echo [ ] Finishing...
 if %progress_finishing%==1 echo [X] Finishing...
 
-
+call :patching_fast_travel_%percent%
+goto patching_fast_travel_100
 
 ::Download files
+:patching_fast_travel_1
 if %percent%==1 md WAD
 if %percent%==1 if not exist IOSPatcher md IOSPatcher
 if %percent%==1 if not exist "IOSPatcher/00000006-31.delta" curl -s -S --insecure "%FilesHostedOn%/IOSPatcher/00000006-31.delta" --output IOSPatcher/00000006-31.delta
@@ -2136,12 +2250,14 @@ if %percent%==1 if not exist "IOSPatcher/00000006-80.delta" curl -s -S --insecur
 if %percent%==1 set /a temperrorlev=%errorlevel%
 if %percent%==1 set modul=Downloading 06-80.delta
 if %percent%==1 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_2
 if %percent%==2 if not exist "IOSPatcher/00000006-80.delta" curl -s -S --insecure "%FilesHostedOn%/IOSPatcher/00000006-80.delta" --output IOSPatcher/00000006-80.delta
 if %percent%==2 set /a temperrorlev=%errorlevel%
 if %percent%==2 set modul=Downloading 06-80.delta
 if %percent%==2 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_3
 if %percent%==3 if not exist "IOSPatcher/libWiiSharp.dll" curl -s -S --insecure "%FilesHostedOn%/IOSPatcher/libWiiSharp.dll" --output IOSPatcher/libWiiSharp.dll
 if %percent%==3 set /a temperrorlev=%errorlevel%
 if %percent%==3 set modul=Downloading libWiiSharp.dll
@@ -2151,17 +2267,21 @@ if %percent%==3 if not exist "IOSPatcher/Sharpii.exe" curl -s -S --insecure "%Fi
 if %percent%==3 set /a temperrorlev=%errorlevel%
 if %percent%==3 set modul=Downloading Sharpii.exe
 if %percent%==3 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_4
 if %percent%==4 if not exist "IOSPatcher/WadInstaller.dll" curl -s -S --insecure "%FilesHostedOn%/IOSPatcher/WadInstaller.dll" --output IOSPatcher/WadInstaller.dll
 if %percent%==4 set /a temperrorlev=%errorlevel%
 if %percent%==4 set modul=Downloading WadInstaller.dll
 if %percent%==4 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_5
 if %percent%==5 if not exist "IOSPatcher/xdelta3.exe" curl -s -S --insecure "%FilesHostedOn%/IOSPatcher/xdelta3.exe" --output IOSPatcher/xdelta3.exe
 if %percent%==5 set /a temperrorlev=%errorlevel%
 if %percent%==5 set modul=Downloading xdelta3.exe
 if %percent%==5 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 ::EVC
+:patching_fast_travel_6
 if %percent%==6 if not exist EVCPatcher/patch md EVCPatcher\patch
 if %percent%==6 if not exist EVCPatcher/dwn md EVCPatcher\dwn
 if %percent%==6 if not exist EVCPatcher/dwn/0001000148414A45v512 md EVCPatcher\dwn\0001000148414A45v512
@@ -2171,17 +2291,19 @@ if %percent%==6 if not exist "EVCPatcher/patch/Europe.delta" curl -s -S --insecu
 if %percent%==6 set /a temperrorlev=%errorlevel%
 if %percent%==6 set modul=Downloading Europe Delta
 if %percent%==6 if not %temperrorlev%==0 goto error_patching
-
 if %percent%==6 if not exist "EVCPatcher/patch/USA.delta" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/patch/USA.delta" --output EVCPatcher/patch/USA.delta
 if %percent%==6 set /a temperrorlev=%errorlevel%
 if %percent%==6 set modul=Downloading USA Delta
 if %percent%==6 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_7
 if %percent%==7 if not exist "EVCPatcher/NUS_Downloader_Decrypt.exe" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/NUS_Downloader_Decrypt.exe" --output EVCPatcher/NUS_Downloader_Decrypt.exe
 if %percent%==7 set /a temperrorlev=%errorlevel%
 if %percent%==7 set modul=Downloading decrypter
 if %percent%==7 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
+:patching_fast_travel_8
 if %percent%==8 if not exist "EVCPatcher/patch/xdelta3.exe" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/patch/xdelta3.exe" --output EVCPatcher/patch/xdelta3.exe
 if %percent%==8 set /a temperrorlev=%errorlevel%
 if %percent%==8 set modul=Downloading xdelta3.exe
@@ -2196,17 +2318,18 @@ if %percent%==8 if not exist "EVCPatcher/pack/Sharpii.exe" curl -s -S --insecure
 if %percent%==8 set /a temperrorlev=%errorlevel%
 if %percent%==8 set modul=Downloading Sharpii.exe
 if %percent%==8 if not %temperrorlev%==0 goto error_patching
-	
 if %percent%==8 if not exist "EVCPatcher/dwn/Sharpii.exe" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/dwn/Sharpii.exe" --output EVCPatcher/dwn/Sharpii.exe
 if %percent%==8 set /a temperrorlev=%errorlevel%
 if %percent%==8 set modul=Downloading Sharpii.exe
 if %percent%==8 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_9
 if %percent%==9 if not exist "EVCPatcher/dwn/libWiiSharp.dll" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/dwn/libWiiSharp.dll" --output EVCPatcher/dwn/libWiiSharp.dll
 if %percent%==9 set /a temperrorlev=%errorlevel%
 if %percent%==9 set modul=Downloading libWiiSharp.dll
 if %percent%==9 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_10
 if %percent%==10 if not exist "EVCPatcher/dwn/0001000148414A45v512/cetk" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/dwn/0001000148414A45v512/cetk" --output EVCPatcher/dwn/0001000148414A45v512/cetk
 if %percent%==10 set /a temperrorlev=%errorlevel%
 if %percent%==10 set modul=Downloading USA CETK
@@ -2216,8 +2339,10 @@ if %percent%==10 if not exist "EVCPatcher/dwn/0001000148414A50v512/cetk" curl -s
 if %percent%==10 set /a temperrorlev=%errorlevel%
 if %percent%==10 set modul=Downloading EUR CETK
 if %percent%==10 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 ::CMOC
+:patching_fast_travel_11
 if %percent%==11 if not exist CMOCPatcher/patch md CMOCPatcher\patch
 if %percent%==11 if not exist CMOCPatcher/dwn md CMOCPatcher\dwn
 if %percent%==11 if not exist CMOCPatcher/dwn/0001000148415045v512 md CMOCPatcher\dwn\0001000148415045v512
@@ -2228,58 +2353,66 @@ if %percent%==11 if not exist "CMOCPatcher/patch/00000004_Europe.delta" curl -s 
 if %percent%==11 set /a temperrorlev=%errorlevel%
 if %percent%==11 set modul=Downloading Europe Delta
 if %percent%==11 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_12
 if %percent%==12 if not exist "CMOCPatcher/patch/00000001_USA.delta" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/patch/00000001_USA.delta" --output CMOCPatcher/patch/00000001_USA.delta
 if %percent%==12 if not exist "CMOCPatcher/patch/00000004_USA.delta" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/patch/00000004_USA.delta" --output CMOCPatcher/patch/00000004_USA.delta
 if %percent%==12 set /a temperrorlev=%errorlevel%
 if %percent%==12 set modul=Downloading USA Delta
 if %percent%==12 if not %temperrorlev%==0 goto error_patching
-
 if %percent%==12 if not exist "CMOCPatcher/NUS_Downloader_Decrypt.exe" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/NUS_Downloader_Decrypt.exe" --output CMOCPatcher/NUS_Downloader_Decrypt.exe
 if %percent%==12 set /a temperrorlev=%errorlevel%
 if %percent%==12 set modul=Downloading decrypter
 if %percent%==12 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_13
 if %percent%==13 if not exist "CMOCPatcher/patch/xdelta3.exe" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/patch/xdelta3.exe" --output CMOCPatcher/patch/xdelta3.exe
 if %percent%==13 set /a temperrorlev=%errorlevel%
 if %percent%==13 set modul=Downloading xdelta3.exe
 if %percent%==13 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_14
 if %percent%==14 if not exist "CMOCPatcher/pack/libWiiSharp.dll" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/pack/libWiiSharp.dll" --output "CMOCPatcher/pack/libWiiSharp.dll"
 if %percent%==14 set /a temperrorlev=%errorlevel%
 if %percent%==14 set modul=Downloading libWiiSharp.dll
 if %percent%==14 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_15
 if %percent%==15 if not exist "CMOCPatcher/pack/Sharpii.exe" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/pack/Sharpii.exe" --output CMOCPatcher/pack/Sharpii.exe
 if %percent%==15 set /a temperrorlev=%errorlevel%
 if %percent%==15 set modul=Downloading Sharpii.exe
 if %percent%==15 if not %temperrorlev%==0 goto error_patching
-	
+goto patching_fast_travel_100
+:patching_fast_travel_16
 if %percent%==16 if not exist "CMOCPatcher/dwn/Sharpii.exe" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/Sharpii.exe" --output CMOCPatcher/dwn/Sharpii.exe
 if %percent%==16 set /a temperrorlev=%errorlevel%
 if %percent%==16 set modul=Downloading Sharpii.exe
 if %percent%==16 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_17
 if %percent%==17 if not exist "CMOCPatcher/dwn/libWiiSharp.dll" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/libWiiSharp.dll" --output CMOCPatcher/dwn/libWiiSharp.dll
 if %percent%==17 set /a temperrorlev=%errorlevel%
 if %percent%==17 set modul=Downloading libWiiSharp.dll
 if %percent%==17 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_18
 if %percent%==18 if not exist "CMOCPatcher/dwn/0001000148415045v512/cetk" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/0001000148415045v512/cetk" --output CMOCPatcher/dwn/0001000148415045v512/cetk
 if %percent%==18 if not exist "CMOCPatcher/dwn/0001000148415045v512/cert" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/0001000148415045v512/cert" --output CMOCPatcher/dwn/0001000148415045v512/cert
 if %percent%==18 set /a temperrorlev=%errorlevel%
 if %percent%==18 set modul=Downloading USA CETK
 if %percent%==18 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_19
 if %percent%==19 if not exist "CMOCPatcher/dwn/0001000148415050v512/cetk" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/0001000148415050v512/cetk" --output CMOCPatcher/dwn/0001000148415050v512/cetk
 if %percent%==19 if not exist "CMOCPatcher/dwn/0001000148415050v512/cert" curl -s -S --insecure "%FilesHostedOn%/CMOCPatcher/dwn/0001000148415050v512/cert" --output CMOCPatcher/dwn/0001000148415050v512/cert
 if %percent%==19 set /a temperrorlev=%errorlevel%
 if %percent%==19 set modul=Downloading EUR CETK
 if %percent%==19 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 
 ::NC
-
+:patching_fast_travel_20
 if %percent%==20 if not exist NCPatcher/patch md NCPatcher\patch
 if %percent%==20 if not exist NCPatcher/dwn md NCPatcher\dwn
 if %percent%==20 if not exist NCPatcher/dwn/0001000148415450v1792 md NCPatcher\dwn\0001000148415450v1792
@@ -2299,7 +2432,8 @@ if %percent%==20 if not exist "NCPatcher/NUS_Downloader_Decrypt.exe" curl -s -S 
 if %percent%==20 set /a temperrorlev=%errorlevel%
 if %percent%==20 set modul=Downloading Decrypter
 if %percent%==20 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_21
 if %percent%==21 if not exist "NCPatcher/patch/xdelta3.exe" curl -s -S --insecure "%FilesHostedOn%/NCPatcher/patch/xdelta3.exe" --output NCPatcher/patch/xdelta3.exe
 if %percent%==21 set /a temperrorlev=%errorlevel%
 if %percent%==21 set modul=Downloading xdelta3.exe
@@ -2314,17 +2448,20 @@ if %percent%==21 if not exist "NCPatcher/pack/Sharpii.exe" curl -s -S --insecure
 if %percent%==21 set /a temperrorlev=%errorlevel%
 if %percent%==21 set modul=Downloading Sharpii.exe
 if %percent%==21 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_22
 if %percent%==22 if not exist "NCPatcher/dwn/Sharpii.exe" curl -s -S --insecure "%FilesHostedOn%/NCPatcher/dwn/Sharpii.exe" --output NCPatcher/dwn/Sharpii.exe
 if %percent%==22 set /a temperrorlev=%errorlevel%
 if %percent%==22 set modul=Downloading Sharpii.exe
 if %percent%==22 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_23
 if %percent%==23 if not exist "NCPatcher/dwn/libWiiSharp.dll" curl -s -S --insecure "%FilesHostedOn%/NCPatcher/dwn/libWiiSharp.dll" --output NCPatcher/dwn/libWiiSharp.dll
 if %percent%==23 set /a temperrorlev=%errorlevel%
 if %percent%==23 set modul=Downloading libWiiSharp.dll
 if %percent%==23 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_24
 if %percent%==24 if not exist "NCPatcher/dwn/0001000148415445v1792/cetk" curl -s -S --insecure "%FilesHostedOn%/NCPatcher/dwn/0001000148415445v1792/cetk" --output NCPatcher/dwn/0001000148415445v1792/cetk
 if %percent%==24 set /a temperrorlev=%errorlevel%
 if %percent%==24 set modul=Downloading USA CETK
@@ -2334,8 +2471,10 @@ if %percent%==24 if not exist "NCPatcher/dwn/0001000148415450v1792/cetk" curl -s
 if %percent%==24 set /a temperrorlev=%errorlevel%
 if %percent%==24 set modul=Downloading EUR CETK
 if %percent%==24 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 ::Everything else
+:patching_fast_travel_25
 if %percent%==25 if not exist apps md apps
 if %percent%==25 if not exist apps/Mail-Patcher md apps\Mail-Patcher
 if %percent%==25 if not exist "apps/Mail-Patcher/boot.dol" curl -s -S --insecure "%FilesHostedOn%/apps/Mail-Patcher/boot.dol" --output apps/Mail-Patcher/boot.dol
@@ -2354,8 +2493,9 @@ if %percent%==25 if not exist "apps/Mail-Patcher/meta.xml" curl -s -S --insecure
 if %percent%==25 set /a temperrorlev=%errorlevel%
 if %percent%==25 set modul=Downloading Mail Patcher
 if %percent%==25 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
-
+:patching_fast_travel_26
 if %percent%==26 if not exist apps/WiiModLite md apps\WiiModLite
 if %percent%==26 if not exist apps/Mail-Patcher md apps\Mail-Patcher
 if %percent%==26 if not exist "apps/WiiModLite/boot.dol" curl -s -S --insecure "%FilesHostedOn%/apps/WiiModLite/boot.dol" --output apps/WiiModLite/boot.dol
@@ -2367,7 +2507,8 @@ if %percent%==26 if not exist "apps/WiiModLite/database.txt" curl -s -S --insecu
 if %percent%==26 set /a temperrorlev=%errorlevel%
 if %percent%==26 set modul=Downloading Wii Mod Lite
 if %percent%==26 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_27
 if %percent%==27 if not exist "apps/WiiModLite/icon.png" curl -s -S --insecure "%FilesHostedOn%/apps/WiiModLite/icon.png" --output apps/WiiModLite/icon.png
 if %percent%==27 set /a temperrorlev=%errorlevel%
 if %percent%==27 set modul=Downloading Wii Mod Lite
@@ -2377,153 +2518,181 @@ if %percent%==27 if not exist "apps/WiiModLite/icon.png" curl -s -S --insecure "
 if %percent%==27 set /a temperrorlev=%errorlevel%
 if %percent%==27 set modul=Downloading Wii Mod Lite
 if %percent%==27 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
+:patching_fast_travel_28
 if %percent%==28 if not exist "apps/WiiModLite/meta.xml" curl -s -S --insecure "%FilesHostedOn%/apps/WiiModLite/meta.xml" --output apps/WiiModLite/meta.xml
 if %percent%==28 set /a temperrorlev=%errorlevel%
 if %percent%==28 set modul=Downloading Wii Mod Lite
 if %percent%==28 if not %temperrorlev%==0 goto error_patching
-
 if %percent%==28 if not exist "apps/WiiModLite/wiimod.txt" curl -s -S --insecure "%FilesHostedOn%/apps/WiiModLite/wiimod.txt" --output apps/WiiModLite/wiimod.txt
 if %percent%==28 set /a temperrorlev=%errorlevel%
 if %percent%==28 set modul=Downloading Wii Mod Lite
 if %percent%==28 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_29
 if %percent%==29 if not exist "EVCPatcher/patch/Europe.delta" curl -s -S --insecure "%FilesHostedOn%EVCPatcher/patch/Europe.delta" --output EVCPatcher/patch/Europe.delta
 if %percent%==29 set /a temperrorlev=%errorlevel%
 if %percent%==29 set modul=Downloading Europe Delta
 if %percent%==29 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_30
 if %percent%==30 if not exist "EVCPatcher/patch/USA.delta" curl -s -S --insecure "%FilesHostedOn%/EVCPatcher/patch/USA.delta" --output EVCPatcher/patch/USA.delta
 if %percent%==30 set /a temperrorlev=%errorlevel%
 if %percent%==30 set /a progress_downloading=1
 if %percent%==30 set modul=Downloading Wii Mod Lite
 if %percent%==30 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 ::IOS Patcher
+:patching_fast_travel_31
 if %custominstall_ios%==1 if %percent%==31 call IOSPatcher\Sharpii.exe NUSD -IOS 31 -v latest -o IOSPatcher\IOS31-old.wad -wad >NUL
 if %custominstall_ios%==1 if %percent%==31 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==31 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==31 if not %temperrorlev%==0 goto error_patching
-
 if %custominstall_ios%==1 if %percent%==31 call IOSPatcher\Sharpii.exe NUSD -IOS 80 -v latest -o IOSPatcher\IOS80-old.wad -wad >NUL
 if %custominstall_ios%==1 if %percent%==31 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==31 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==31 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_32
 if %custominstall_ios%==1 if %percent%==32 call IOSPatcher\Sharpii.exe WAD -u IOSPatcher\IOS31-old.wad IOSPatcher/IOS31/ >NUL
 if %custominstall_ios%==1 if %percent%==32 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==32 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==32 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_33
 if %custominstall_ios%==1 if %percent%==33 call IOSPatcher\Sharpii.exe WAD -u IOSPatcher\IOS80-old.wad IOSPatcher\IOS80/ >NUL
 if %custominstall_ios%==1 if %percent%==33 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==33 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==33 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_34
 if %custominstall_ios%==1 if %percent%==34 move /y IOSPatcher\IOS31\00000006.app IOSPatcher\00000006.app >NUL
 if %custominstall_ios%==1 if %percent%==34 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==34 set modul=move.exe
 if %custominstall_ios%==1 if %percent%==34 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_35
 if %custominstall_ios%==1 if %percent%==35 call IOSPatcher\xdelta3.exe -f -d -s IOSPatcher\00000006.app IOSPatcher\00000006-31.delta IOSPatcher\IOS31\00000006.app >NUL
 if %custominstall_ios%==1 if %percent%==35 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==35 set modul=xdelta.exe
 if %custominstall_ios%==1 if %percent%==35 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_36
 if %custominstall_ios%==1 if %percent%==36 move /y IOSPatcher\IOS80\00000006.app IOSPatcher\00000006.app >NUL
 if %custominstall_ios%==1 if %percent%==36 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==36 set modul=move.exe
 if %custominstall_ios%==1 if %percent%==36 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_37
 if %custominstall_ios%==1 if %percent%==37 call IOSPatcher\xdelta3.exe -f -d -s IOSPatcher\00000006.app IOSPatcher\00000006-80.delta IOSPatcher\IOS80\00000006.app >NUL
 if %custominstall_ios%==1 if %percent%==37 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==37 set modul=xdelta3.exe
 if %custominstall_ios%==1 if %percent%==37 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_38
 if %custominstall_ios%==1 if %percent%==38 if not exist IOSPatcher\WAD mkdir IOSPatcher\WAD
 if %custominstall_ios%==1 if %percent%==38 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==38 set modul=mkdir.exe
 if %custominstall_ios%==1 if %percent%==38 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_39
 if %custominstall_ios%==1 if %percent%==39 call IOSPatcher\Sharpii.exe WAD -p IOSPatcher\IOS31\ IOSPatcher\WAD\IOS31.wad -fs >NUL
 if %custominstall_ios%==1 if %percent%==39 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==39 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==39 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_40
 if %custominstall_ios%==1 if %percent%==40 call IOSPatcher\Sharpii.exe WAD -p IOSPatcher\IOS80\ IOSPatcher\WAD\IOS80.wad -fs >NUL
 if %custominstall_ios%==1 if %percent%==40 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==40 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==40 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_40
 if %custominstall_ios%==1 if %percent%==40 del IOSPatcher\00000006.app /q >NUL
 if %custominstall_ios%==1 if %percent%==40 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==40 set modul=del.exe
 if %custominstall_ios%==1 if %percent%==40 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_41
 if %custominstall_ios%==1 if %percent%==41 del IOSPatcher\IOS31-old.wad /q >NUL
 if %custominstall_ios%==1 if %percent%==41 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==41 set modul=del.exe
 if %custominstall_ios%==1 if %percent%==41 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_42
 if %custominstall_ios%==1 if %percent%==42 del IOSPatcher\IOS80-old.wad /q >NUL
 if %custominstall_ios%==1 if %percent%==42 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==42 set modul=del.exe
 if %custominstall_ios%==1 if %percent%==42 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_43
 if %custominstall_ios%==1 if %percent%==43 if exist IOSPatcher\IOS31 rmdir /s /q IOSPatcher\IOS31 >NUL
 if %custominstall_ios%==1 if %percent%==43 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==43 set modul=rmdir.exe
 if %custominstall_ios%==1 if %percent%==43 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_44
 if %custominstall_ios%==1 if %percent%==44 if exist IOSPatcher\IOS80 rmdir /s /q IOSPatcher\IOS80 >NUL
 if %custominstall_ios%==1 if %percent%==44 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==44 set modul=rmdir.exe
 if %custominstall_ios%==1 if %percent%==44 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_45
 if %custominstall_ios%==1 if %percent%==45 call IOSPatcher\Sharpii.exe IOS IOSPatcher\WAD\IOS31.wad -fs -es -np -vp>NUL
 if %custominstall_ios%==1 if %percent%==45 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==45 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==45 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_46
 if %custominstall_ios%==1 if %percent%==46 call IOSPatcher\Sharpii.exe IOS IOSPatcher\WAD\IOS80.wad -fs -es -np -vp>NUL
 if %custominstall_ios%==1 if %percent%==46 set /a temperrorlev=%errorlevel%
 if %custominstall_ios%==1 if %percent%==46 set modul=Sharpii.exe
 if %custominstall_ios%==1 if %percent%==46 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_47
 if %custominstall_ios%==1 if %percent%==47 if not exist WAD md WAD
 if %custominstall_ios%==1 if %percent%==47 move "IOSPatcher\WAD\IOS31.wad" "WAD"
 if %custominstall_ios%==1 if %percent%==47 move "IOSPatcher\WAD\IOS80.wad" "WAD"
-
+goto patching_fast_travel_100
+:patching_fast_travel_48
 if %custominstall_ios%==1 if %percent%==48 if exist IOSPatcher rmdir /s /q IOSPatcher
 if %custominstall_ios%==1 if %percent%==48 set /a progress_ios=1
+goto patching_fast_travel_100
 ::EVC Patcher
-
+:patching_fast_travel_50
 if %custominstall_evc%==1 if %percent%==50 if not exist 0001000148414A50v512 md 0001000148414A50v512
 if %custominstall_evc%==1 if %percent%==50 if not exist 0001000148414A45v512 md 0001000148414A45v512
 if %custominstall_evc%==1 if %percent%==50 if not exist 0001000148414A50v512\cetk copy /y "EVCPatcher\dwn\0001000148414A50v512\cetk" "0001000148414A50v512\cetk"
 
 if %custominstall_evc%==1 if %percent%==50 if not exist 0001000148414A45v512\cetk copy /y "EVCPatcher\dwn\0001000148414A45v512\cetk" "0001000148414A45v512\cetk"
 
+goto patching_fast_travel_100
 ::USA
+:patching_fast_travel_52
 if %custominstall_evc%==1 if %percent%==52 if %evcregion%==2 call EVCPatcher\dwn\sharpii.exe NUSD -ID 0001000148414A45 -v 512 -encrypt >NUL
 ::PAL
 if %custominstall_evc%==1 if %percent%==52 if %evcregion%==1 call EVCPatcher\dwn\sharpii.exe NUSD -ID 0001000148414A50 -v 512 -encrypt >NUL
 if %custominstall_evc%==1 if %percent%==52 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==52 set modul=Downloading EVC
 if %custominstall_evc%==1 if %percent%==52 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_54
 if %custominstall_evc%==1 if %percent%==54 if %evcregion%==1 copy /y "EVCPatcher\NUS_Downloader_Decrypt.exe" "0001000148414A50v512"
 if %custominstall_evc%==1 if %percent%==54 if %evcregion%==2 copy /y "EVCPatcher\NUS_Downloader_Decrypt.exe" "0001000148414A45v512"
 if %custominstall_evc%==1 if %percent%==54 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==54 set modul=Copying NDC.exe
 if %custominstall_evc%==1 if %percent%==54 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_56
 if %custominstall_evc%==1 if %percent%==56 if %evcregion%==1 ren "0001000148414A50v512\tmd.512" "tmd"
 if %custominstall_evc%==1 if %percent%==56 if %evcregion%==2 ren "0001000148414A45v512\tmd.512" "tmd"
 if %custominstall_evc%==1 if %percent%==56 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==56 set modul=Renaming files [Delete everything except RiiConnect24Patcher.bat]
 if %custominstall_evc%==1 if %percent%==56 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_57
 if %custominstall_evc%==1 if %percent%==57 if %evcregion%==1 cd 0001000148414A50v512
 if %custominstall_evc%==1 if %percent%==57 if %evcregion%==1 call NUS_Downloader_Decrypt.exe >NUL
 if %custominstall_evc%==1 if %percent%==57 if %evcregion%==2 cd 0001000148414A45v512
@@ -2532,56 +2701,66 @@ if %custominstall_evc%==1 if %percent%==57 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==57 set modul=Decrypter error
 if %custominstall_evc%==1 if %percent%==57 if not %temperrorlev%==0 cd..& goto error_patching
 if %custominstall_evc%==1 if %percent%==57 cd..
-
+goto patching_fast_travel_100
+:patching_fast_travel_60
 if %custominstall_evc%==1 if %percent%==60 if %evcregion%==1 move /y "0001000148414A50v512\HAJP.wad" "EVCPatcher\pack"
 if %custominstall_evc%==1 if %percent%==60 if %evcregion%==2 move /y "0001000148414A45v512\HAJE.wad" "EVCPatcher\pack"
 if %custominstall_evc%==1 if %percent%==60 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==60 set modul=move.exe
 if %custominstall_evc%==1 if %percent%==60 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_62
 if %custominstall_evc%==1 if %percent%==62 if %evcregion%==1 call EVCPatcher\pack\Sharpii.exe WAD -u EVCPatcher\pack\HAJP.wad EVCPatcher\pack\unencrypted >NUL
 if %custominstall_evc%==1 if %percent%==62 if %evcregion%==2 call EVCPatcher\pack\Sharpii.exe WAD -u EVCPatcher\pack\HAJE.wad EVCPatcher\pack\unencrypted >NUL
-
+goto patching_fast_travel_100
+:patching_fast_travel_63
 if %custominstall_evc%==1 if %percent%==63 move /y "EVCPatcher\pack\unencrypted\00000001.app" "00000001.app"
 if %custominstall_evc%==1 if %percent%==63 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==63 set modul=move.exe
 if %custominstall_evc%==1 if %percent%==63 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_65
 if %custominstall_evc%==1 if %percent%==65 if %evcregion%==1 call EVCPatcher\patch\xdelta3.exe -f -d -s 00000001.app EVCPatcher\patch\Europe.delta EVCPatcher\pack\unencrypted\00000001.app
 if %custominstall_evc%==1 if %percent%==65 if %evcregion%==2 call EVCPatcher\patch\xdelta3.exe -f -d -s 00000001.app EVCPatcher\patch\USA.delta EVCPatcher\pack\unencrypted\00000001.app
 if %custominstall_evc%==1 if %percent%==65 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==65 set modul=xdelta.exe EVC
 if %custominstall_evc%==1 if %percent%==65 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_67
 if %custominstall_evc%==1 if %percent%==67 if %evcregion%==1 call EVCPatcher\pack\Sharpii.exe WAD -p "EVCPatcher\pack\unencrypted" "WAD\Everybody Votes Channel (Europe) (Channel) (RiiConnect24)" -f 
 if %custominstall_evc%==1 if %percent%==67 if %evcregion%==2 call EVCPatcher\pack\Sharpii.exe WAD -p "EVCPatcher\pack\unencrypted" "WAD\Everybody Votes Channel (USA) (Channel) (RiiConnect24)" -f
 if %custominstall_evc%==1 if %percent%==67 set /a temperrorlev=%errorlevel%
 if %custominstall_evc%==1 if %percent%==67 set modul=Packing EVC WAD
 if %custominstall_evc%==1 if %percent%==67 set /a progress_evc=1
 if %custominstall_evc%==1 if %percent%==67 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 ::CMOC
-
+:patching_fast_travel_68
 if %custominstall_cmoc%==1 if %percent%==68 if not exist 0001000148415050v512 md 0001000148415050v512
 if %custominstall_cmoc%==1 if %percent%==68 if not exist 0001000148415045v512 md 0001000148415045v512
 if %custominstall_cmoc%==1 if %percent%==68 if not exist 0001000148415050v512\cetk copy /y "CMOCPatcher\dwn\0001000148415050v512\cetk" "0001000148415050v512\cetk"
 
 if %custominstall_cmoc%==1 if %percent%==68 if not exist 0001000148415045v512\cetk copy /y "CMOCPatcher\dwn\0001000148415045v512\cetk" "0001000148415045v512\cetk"
 
+goto patching_fast_travel_100
 ::USA
+:patching_fast_travel_70
 if %custominstall_cmoc%==1 if %percent%==70 if %evcregion%==2 call CMOCPatcher\dwn\sharpii.exe NUSD -ID 0001000148415045 -v 512 -encrypt >NUL
 ::PAL
 if %custominstall_cmoc%==1 if %percent%==70 if %evcregion%==1 call CMOCPatcher\dwn\sharpii.exe NUSD -ID 0001000148415050 -v 512 -encrypt >NUL
 if %custominstall_cmoc%==1 if %percent%==70 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==70 set modul=Downloading CMOC
 if %custominstall_cmoc%==1 if %percent%==70 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_71
 if %custominstall_cmoc%==1 if %percent%==71 if %evcregion%==1 copy /y "CMOCPatcher\NUS_Downloader_Decrypt.exe" "0001000148415050v512"
 if %custominstall_cmoc%==1 if %percent%==71 if %evcregion%==2 copy /y "CMOCPatcher\NUS_Downloader_Decrypt.exe" "0001000148415045v512"
 if %custominstall_cmoc%==1 if %percent%==71 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==71 set modul=Copying NDC.exe
 if %custominstall_cmoc%==1 if %percent%==71 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_72
 if %custominstall_cmoc%==1 if %percent%==72 if %evcregion%==1 ren "0001000148415050v512\tmd.512" "tmd"
 if %custominstall_cmoc%==1 if %percent%==72 if %evcregion%==2 ren "0001000148415045v512\tmd.512" "tmd"
 if %custominstall_cmoc%==1 if %percent%==72 set /a temperrorlev=%errorlevel%
@@ -2596,22 +2775,26 @@ if %custominstall_cmoc%==1 if %percent%==72 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==72 set modul=Decrypter error
 if %custominstall_cmoc%==1 if %percent%==72 if not %temperrorlev%==0 cd..& goto error_patching
 if %custominstall_cmoc%==1 if %percent%==72 cd..
-
+goto patching_fast_travel_100
+:patching_fast_travel_74
 if %custominstall_cmoc%==1 if %percent%==74 if %evcregion%==1 move /y "0001000148415050v512\HAPP.wad" "CMOCPatcher\pack"
 if %custominstall_cmoc%==1 if %percent%==74 if %evcregion%==2 move /y "0001000148415045v512\HAPE.wad" "CMOCPatcher\pack"
 if %custominstall_cmoc%==1 if %percent%==74 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==74 set modul=move.exe
 if %custominstall_cmoc%==1 if %percent%==74 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_75
 if %custominstall_cmoc%==1 if %percent%==75 if %evcregion%==1 call CMOCPatcher\pack\Sharpii.exe WAD -u CMOCPatcher\pack\HAPP.wad CMOCPatcher\pack\unencrypted >NUL
 if %custominstall_cmoc%==1 if %percent%==75 if %evcregion%==2 call CMOCPatcher\pack\Sharpii.exe WAD -u CMOCPatcher\pack\HAPE.wad CMOCPatcher\pack\unencrypted >NUL
-
+goto patching_fast_travel_100
+:patching_fast_travel_76
 if %custominstall_cmoc%==1 if %percent%==76 move /y "CMOCPatcher\pack\unencrypted\00000001.app" "00000001.app"
 if %custominstall_cmoc%==1 if %percent%==76 move /y "CMOCPatcher\pack\unencrypted\00000004.app" "00000004.app"
 if %custominstall_cmoc%==1 if %percent%==76 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==76 set modul=move.exe
 if %custominstall_cmoc%==1 if %percent%==76 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_77
 if %custominstall_cmoc%==1 if %percent%==77 if %evcregion%==1 call CMOCPatcher\patch\xdelta3.exe -f -d -s 00000001.app CMOCPatcher\patch\00000001_Europe.delta CMOCPatcher\pack\unencrypted\00000001.app
 if %custominstall_cmoc%==1 if %percent%==77 if %evcregion%==1 call CMOCPatcher\patch\xdelta3.exe -f -d -s 00000004.app CMOCPatcher\patch\00000004_Europe.delta CMOCPatcher\pack\unencrypted\00000004.app
 if %custominstall_cmoc%==1 if %percent%==77 if %evcregion%==2 call CMOCPatcher\patch\xdelta3.exe -f -d -s 00000001.app CMOCPatcher\patch\00000001_USA.delta CMOCPatcher\pack\unencrypted\00000001.app
@@ -2619,13 +2802,15 @@ if %custominstall_cmoc%==1 if %percent%==77 if %evcregion%==2 call CMOCPatcher\p
 if %custominstall_cmoc%==1 if %percent%==77 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==77 set modul=xdelta.exe CMOC
 if %custominstall_cmoc%==1 if %percent%==77 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_79
 if %custominstall_cmoc%==1 if %percent%==79 if %evcregion%==1 call CMOCPatcher\pack\Sharpii.exe WAD -p "CMOCPatcher\pack\unencrypted" "WAD\Mii Contest Channel (Europe) (Channel) (RiiConnect24)" -f 
 if %custominstall_cmoc%==1 if %percent%==79 if %evcregion%==2 call CMOCPatcher\pack\Sharpii.exe WAD -p "CMOCPatcher\pack\unencrypted" "WAD\Check Mii Out Channel (USA) (Channel) (RiiConnect24)" -f
 if %custominstall_cmoc%==1 if %percent%==79 set /a temperrorlev=%errorlevel%
 if %custominstall_cmoc%==1 if %percent%==79 set modul=Packing CMOC WAD
 if %custominstall_cmoc%==1 if %percent%==79 set /a progress_cmoc=1
 if %custominstall_cmoc%==1 if %percent%==79 if not %temperrorlev%==0 goto error_patching
+goto patching_fast_travel_100
 
 
 
@@ -2638,13 +2823,14 @@ if %custominstall_cmoc%==1 if %percent%==79 if not %temperrorlev%==0 goto error_
 
 ::NC
 
-
+:patching_fast_travel_81
 if %custominstall_nc%==1 if %percent%==81 if not exist 0001000148415450v1792 md 0001000148415450v1792
 if %custominstall_nc%==1 if %percent%==81 if not exist 0001000148415445v1792 md 0001000148415445v1792
 if %custominstall_nc%==1 if %percent%==81 if not exist 0001000148415450v1792\cetk copy /y "NCPatcher\dwn\0001000148415450v1792\cetk" "0001000148415450v1792\cetk"
 
 if %custominstall_nc%==1 if %percent%==81 if not exist 0001000148415445v1792\cetk copy /y "NCPatcher\dwn\0001000148415445v1792\cetk" "0001000148415445v1792\cetk"
 
+:patching_fast_travel_85
 ::USA
 if %custominstall_nc%==1 if %percent%==85 if %evcregion%==2 call NCPatcher\dwn\sharpii.exe NUSD -ID 0001000148415445 -v 1792 -encrypt >NUL
 ::PAL
@@ -2652,19 +2838,22 @@ if %custominstall_nc%==1 if %percent%==85 if %evcregion%==1 call NCPatcher\dwn\s
 if %custominstall_nc%==1 if %percent%==85 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==85 set modul=Downloading NC
 if %custominstall_nc%==1 if %percent%==85 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_86
 if %custominstall_nc%==1 if %percent%==86 if %evcregion%==1 copy /y "NCPatcher\NUS_Downloader_Decrypt.exe" "0001000148415450v1792"
 if %custominstall_nc%==1 if %percent%==86 if %evcregion%==2 copy /y "NCPatcher\NUS_Downloader_Decrypt.exe" "0001000148415445v1792"
 if %custominstall_nc%==1 if %percent%==86 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==86 set modul=Copying NDC.exe
 if %custominstall_nc%==1 if %percent%==86 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_87
 if %custominstall_nc%==1 if %percent%==87 if %evcregion%==1 ren "0001000148415450v1792\tmd.1792" "tmd"
 if %custominstall_nc%==1 if %percent%==87 if %evcregion%==2 ren "0001000148415445v1792\tmd.1792" "tmd"
 if %custominstall_nc%==1 if %percent%==87 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==87 set modul=Renaming files
 if %custominstall_nc%==1 if %percent%==87 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_88
 if %custominstall_nc%==1 if %percent%==88 if %evcregion%==1 cd 0001000148415450v1792
 if %custominstall_nc%==1 if %percent%==88 if %evcregion%==1 call NUS_Downloader_Decrypt.exe >NUL
 if %custominstall_nc%==1 if %percent%==88 if %evcregion%==2 cd 0001000148415445v1792
@@ -2673,41 +2862,51 @@ if %custominstall_nc%==1 if %percent%==88 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==88 set modul=Decrypter error
 if %custominstall_nc%==1 if %percent%==88 if not %temperrorlev%==0 cd..& goto error_patching
 if %custominstall_nc%==1 if %percent%==88 cd..
-
+goto patching_fast_travel_100
+:patching_fast_travel_89
 if %custominstall_nc%==1 if %percent%==89 if %evcregion%==1 move /y "0001000148415450v1792\HATP.wad" "NCPatcher\pack"
 if %custominstall_nc%==1 if %percent%==89 if %evcregion%==2 move /y "0001000148415445v1792\HATE.wad" "NCPatcher\pack"
 if %custominstall_nc%==1 if %percent%==89 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==89 set modul=move.exe
 if %custominstall_nc%==1 if %percent%==89 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_90
 if %custominstall_nc%==1 if %percent%==90 if %evcregion%==1 call NCPatcher\pack\Sharpii.exe WAD -u NCPatcher\pack\HATP.wad NCPatcher\pack\unencrypted >NUL
 if %custominstall_nc%==1 if %percent%==90 if %evcregion%==2 call NCPatcher\pack\Sharpii.exe WAD -u NCPatcher\pack\HATE.wad NCPatcher\pack\unencrypted >NUL
-
+goto patching_fast_travel_100
+:patching_fast_travel_93
 if %custominstall_nc%==1 if %percent%==93 move /y "NCPatcher\pack\unencrypted\00000001.app" "00000001_NC.app"
 if %custominstall_nc%==1 if %percent%==93 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==93 set modul=move.exe
 if %custominstall_nc%==1 if %percent%==93 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_94
 if %custominstall_nc%==1 if %percent%==94 if %evcregion%==1 call NCPatcher\patch\xdelta3.exe -f -d -s 00000001_NC.app NCPatcher\patch\Europe.delta NCPatcher\pack\unencrypted\00000001.app
 if %custominstall_nc%==1 if %percent%==94 if %evcregion%==2 call NCPatcher\patch\xdelta3.exe -f -d -s 00000001_NC.app NCPatcher\patch\USA.delta NCPatcher\pack\unencrypted\00000001.app
 if %custominstall_nc%==1 if %percent%==94 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==94 set modul=xdelta.exe NC
 if %custominstall_nc%==1 if %percent%==94 if not %temperrorlev%==0 goto error_patching
-
+goto patching_fast_travel_100
+:patching_fast_travel_95
 if %custominstall_nc%==1 if %percent%==95 if %evcregion%==1 call NCPatcher\pack\Sharpii.exe WAD -p "NCPatcher\pack\unencrypted" "WAD\Nintendo Channel (Europe) (Channel) (RiiConnect24)" -f 
-if %custominstall_nc%==1 if %percent%==95 if %evcregion%==2 call NCPatcher\pack\Sharpii.exe WAD -p "NCPatcher\pack\unencrypted" "WAD\Nintnedo Channel (USA) (Channel) (RiiConnect24)" -f
+if %custominstall_nc%==1 if %percent%==95 if %evcregion%==2 call NCPatcher\pack\Sharpii.exe WAD -p "NCPatcher\pack\unencrypted" "WAD\Nintendo Channel (USA) (Channel) (RiiConnect24)" -f
 if %custominstall_nc%==1 if %percent%==95 set /a temperrorlev=%errorlevel%
 if %custominstall_nc%==1 if %percent%==95 set modul=Packing NC WAD
 if %custominstall_nc%==1 if %percent%==95 if not %temperrorlev%==0 goto error_patching
 if %custominstall_nc%==1 if %percent%==95 set /a progress_nc=1
+goto patching_fast_travel_100
 
 ::Final commands
+:patching_fast_travel_98
 if %percent%==98 if not %sdcard%==NUL set /a errorcopying=0
 if %percent%==98 if not %sdcard%==NUL if not exist "%sdcard%:\WAD" md "%sdcard%:\WAD"
 if %percent%==98 if not %sdcard%==NUL if not exist "%sdcard%:\apps" md "%sdcard%:\apps"
+goto patching_fast_travel_100
 
-if %percent%==99 if not %sdcard%==NUL xcopy /y "WAD" "%sdcard%:\WAD" /e >NUL || set /a errorcopying=1
-if %percent%==99 if not %sdcard%==NUL xcopy /y "apps" "%sdcard%:\apps" /e >NUL || set /a errorcopying=1
+:patching_fast_travel_99
+if %percent%==99 echo.&echo Don't worry^^! It might take some time... Now copying files to your SD Card...
+if %percent%==99 if not %sdcard%==NUL xcopy /y "WAD" "%sdcard%:\WAD" /e|| set /a errorcopying=1
+if %percent%==99 if not %sdcard%==NUL xcopy /y "apps" "%sdcard%:\apps" /e|| set /a errorcopying=1
 
 if %percent%==99 if exist 0001000148415045v512 rmdir /s /q 0001000148415045v512
 if %percent%==99 if exist 0001000148415050v512 rmdir /s /q 0001000148415050v512
@@ -2724,13 +2923,15 @@ if %percent%==99 del /q 00000001.app
 if %percent%==99 del /q 00000004.app
 if %percent%==99 del /q 00000001_NC.app
 if %percent%==99 set /a progress_finishing=1
+goto patching_fast_travel_100
+
+
+:patching_fast_travel_100
 
 if %percent%==100 goto 2_4
 ::ping localhost -n 1 >NUL
 
-if "%percent%"=="0" call :random_funfact
-if "%percent%"=="50" call :random_funfact
-
+if /i %ss% GEQ 20 goto random_funfact
 set /a percent=%percent%+1
 goto 2_3
 :2_4
@@ -2738,19 +2939,26 @@ cls
 echo.
 echo %header%
 echo ---------------------------------------------------------------------------------------------------------------------------
-echo Patching done!
+echo Patching done^^!
 echo.
 if %sdcardstatus%==0 echo Please connect your Wii SD Card and copy apps and WAD folder to the root (main folder) of your SD Card. You can find these folders next to RiiConnect24Patcher.bat
 if %sdcardstatus%==1 if %sdcard%==NUL echo Please connect your Wii SD Card and copy apps and WAD folder to the root (main folder) of your SD Card. You can find these folders next to RiiConnect24Patcher.bat
 
-if %sdcardstatus%==1 if not %sdcard%==NUL if %errorcopying%==0 echo Every file is in it's place on your SD Card!
+if %sdcardstatus%==1 if not %sdcard%==NUL if %errorcopying%==0 echo Every file is in it's place on your SD Card^^!
 if %sdcardstatus%==1 if not %sdcard%==NUL if %errorcopying%==1 echo Unfortunately, I wasn't able to put some of the files on your SD Card. Please copy WAD and apps folder manually to the root (main folder) of your SD Card. You can find these folders next to RiiConnect24Patcher.bat.
 echo.
 echo Please proceed with the tutorial that you can find on https://wii.guide/riiconnect24
 echo.
-echo Press any key to close this patcher.
-pause>NUL
-goto end
+echo What to do next?
+echo.
+echo 1. Return to main menu
+echo 2. Close the patcher
+echo 3. Close the patcher and cleanup all temporary data created by the patcher.
+set /p s=Choose: 
+if %s%==1 goto script_start
+if %s%==2 goto end
+if %s%==3 rmdir /s /q "%MainFolder%"&goto end
+goto 2_4
 :end
 set /a exiting=10
 set /a timeouterror=1
@@ -2761,9 +2969,9 @@ cls
 echo.
 echo %header%
 echo ---------------------------------------------------------------------------------------------------------------------------
-echo  [*] Thank you very much for using this patcher! :)
+echo  [*] Thank you very much for using this patcher^^! :)
 echo.
-if %exitmessage%==1 echo Have fun using RiiConnect24!
+if %exitmessage%==1 echo Have fun using RiiConnect24^^!
 echo Closing the patcher in:
 if %exiting%==10 echo :----------: 10
 if %exiting%==9 echo :--------- : 9
@@ -2786,19 +2994,45 @@ goto end1
 if "%modul%"=="Renaming files [Delete everything except RiiConnect24Patcher.bat]" set tempgotonext=2_2&set /a troubleshoot_auto_tool_notification=1& goto troubleshooting_5
 if "%modul%"=="Decrypter error" set tempgotonext=2_2&set /a troubleshoot_auto_tool_notification=1& goto troubleshooting_5
 if "%modul%"=="move.exe" set tempgotonext=2_2&set /a troubleshoot_auto_tool_notification=1& goto troubleshooting_5
-
-goto troubleshooting_auto_tool
-
-
+if "%percent%"=="1" set tempgotonext=2_2&set /a troubleshoot_auto_tool_notification=1& goto troubleshooting_5
 
 
 set /a modul=0
 goto error_patching
 
 
+:no_internet_connection
+cls
+echo %header%                                                                
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.                 
+echo.
+echo ---------------------------------------------------------------------------------------------------------------------------
+echo    /---\   ERROR             
+echo   /     \  There is no internet connection.
+echo  /   ^^!   \ 
+echo  --------- Could not connect to remote server. 
+echo            Check your internet connection or check if your firewall isn't blocking curl.
+echo.
+echo       Press any key to return to main menu.
+echo ---------------------------------------------------------------------------------------------------------------------------
+pause>NUL
+goto begin_main
 
 :error_patching
+if "%temperrorlev%"=="6" goto no_internet_connection
+if "%temperrorlev%"=="7" goto no_internet_connection
 if "%modul%"=="Renaming files [Delete everything except RiiConnect24Patcher.bat]" goto troubleshooting_auto_tool
+if "%percent%"=="1" goto troubleshooting_auto_tool
 cls
 echo %header%                                                                
 echo              `..````                                                  
@@ -2815,11 +3049,12 @@ echo             hmmmmh omMMMMMMMMMmhNMMMmNNNNMMMMMMMMMMM+
 echo ---------------------------------------------------------------------------------------------------------------------------
 echo    /---\   ERROR.              
 echo   /     \  There was an error while patching.
-echo  /   !   \ Error Code: %temperrorlev%
+echo  /   ^^!   \ Error Code: %temperrorlev%
 echo  --------- Failing module: %modul% / %percent%
 echo.
 echo TIP: Consider turning off your antivirus temporarily.
 if %temperrorlev%==-532459699 echo SOLUTION: Please check your internet connection.
+if %temperrorlev%==23 echo ERROR DETAILS: Curl write error. Try moving the patcher to desktop and try again.
 if %temperrorlev%==-2146232576 echo SOLUTION: Please install latest .NET Framework, then try again.  
 echo       Press any key to return to main menu.
 echo ---------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I noticed that even after the latest version of the patcher, 1.1.2.3, there were still people having issues with the patcher auto-updater AND the "Repair Patcher" option causing glitches. After looking at the code it seems to be fixed by just using the "-crlf" curl option on line 1237 (As seen in commit cf4e19c). I also updated the patcher to the latest script, keeping the -crlf option (Which moved to line 1186, See commit a974db3).

All in all a simple fix that I hope solves this updating issue once and for all. (Of course this won't do any good until there's a patcher update AFTER this one, but it will solve the issue going forward.)