### PR TITLE
Add Linux support to detect_sd_card function

### DIFF
--- a/RiiConnect24Patcher.sh
+++ b/RiiConnect24Patcher.sh
@@ -178,13 +178,18 @@ number_2_1 () {
 
 detect_sd_card () {
     sdcard=null
-    for f in /Volumes/*/; do
+    if [ "$machine" = "mac" ]; then
+        dir="/Volumes/*/"
+    elif [ "$machine" = "linux" ]; then
+        dir="/media/$(whoami)/*/"
+    fi
+
+    for f in $dir; do
         if [ -d "$f/apps" ]; then
             sdcard="$f"
             echo "$sdcard"
         fi
     done
-
     number_2_1_summary
 }
 


### PR DESCRIPTION
Linux doesn't have a `/Volumes` folder, instead most distros have standardized on `/media/$USER`. This checks if the script is running on Linux or macOS and sets a variable accordingly. I tested and verified working on my Pop!_OS 20.10 system.