### PR TITLE
Clarify 'brew.sh' is a website

### DIFF
--- a/RiiConnect24Patcher.sh
+++ b/RiiConnect24Patcher.sh
@@ -1076,7 +1076,7 @@ if ! command -v xdelta3
 then
 	case $(uname) in
 		Darwin)
-			print "\"xdelta3\" command not found! Please install brew at \"brew.sh\" then install xdelta3 by typing \"brew install xdelta\" into your terminal.\n\n"
+			print "\"xdelta3\" command not found! Please install brew by going to the website \"https://brew.sh\" then install xdelta3 by typing \"brew install xdelta\" into your terminal.\n\n"
 			exit
 			;;
 		*) 


### PR DESCRIPTION
I've noticed quite a few people are getting stuck using the Unix Patcher on Mac because they aren't realizing that "brew.sh" is a link they need to follow. This PR should clarify that a bit.