### PR TITLE
Revert "Fix SSL issues"

### DIFF
--- a/RiiConnect24Patcher.sh
+++ b/RiiConnect24Patcher.sh
@@ -40,12 +40,12 @@ subtitle () {
 
 # Get file from SketchMaster2001's website
 sketchget() {
-	curl --create-dirs -f -k -L -o "${2}" -S -s --insecure https://sketchmaster2001.github.io/RC24_Patcher/${1}
+	curl --create-dirs -f -k -L -o "${2}" -S -s https://sketchmaster2001.github.io/RC24_Patcher/${1}
 } 
 
 # Get file from RiiConnect24 website and save it to output
 rc24get () {
-	curl --create-dirs -f -k -L -o "${2}" -S -s --insecure https://patcher.rc24.xyz/update/RiiConnect24-Patcher/v1/${1}
+	curl --create-dirs -f -k -L -o "${2}" -S -s https://patcher.rc24.xyz/update/RiiConnect24-Patcher/v1/${1}
 } 
 
 


### PR DESCRIPTION
This reverts commit 8004dc5275c92cebf23297b531308c141df2ab63.

This commit didn't actually fix the SSL issues,
just masked them in an insecure way.

If an SSL error happens to a user something else is really wrong.