### PR TITLE
Add Mac M1 uname support

### DIFF
--- a/RiiConnect24Patcher.sh
+++ b/RiiConnect24Patcher.sh
@@ -1046,8 +1046,12 @@ set -o errtrace
 helpmsg="Open an issue on https://github.com/RiiConnect24/RiiConnect24-Patcher/issues regarding your error. Alternatively, contact either HTV04 #4802 or SketchMaster2001 #8837 on Discord."
 
 case $(uname -m),$(uname) in
-	x86_64,Darwin|arm64,Darwin)
-		sys="(macOS)"
+	x86_64,Darwin)
+		sys="(macOS-x64)"
+		mount=/Volumes
+		;;
+	arm64,Darwin)
+		sys="(macOS-arm64)"
 		mount=/Volumes
 		;;
 	x86_64,*)


### PR DESCRIPTION
Depends on https://github.com/SketchMaster2001/sketchmaster2001.github.io/pull/6. 
Edit: Dependent PR has been merged. This is safe to merge by whoever may want to do so though I will do it myself by this time tomorrow so old compatibility binaries can be removed.

Separates the uname identifier allowing to grab system specific Sharpii files now that M1 support exists in .Net 6.

Requesting a review from @HTV04 just out of procedure, this should be a safe and as long as the binaries are added/updated in the relevant repo this should be good to go for anyone to merge.